### PR TITLE
Make `Result` type `:-` friendly

### DIFF
--- a/examples/Std/OptionAndResult.dfy
+++ b/examples/Std/OptionAndResult.dfy
@@ -97,32 +97,19 @@ module Demo {
     }
   }
 
-  method TestMyFilesystem() {
+  method TestMyFilesystem() returns (r: Result<()>) {
     var fs := new MyFilesystem();
-    // Note: these verbose "outcome.Failure?" patterns will soon
-    // not be needed any more, see https://github.com/dafny-lang/rfcs/pull/1
-    var outcome: Result<()> := fs.CreateFile("test.txt");
-    if outcome.Failure? {
-      print outcome.error, "\n";
-      return;
-    }
-    outcome := fs.WriteFile("test.txt", "Test dummy file");
-    if outcome.Failure? {
-      print outcome.error, "\n";
-      return;
-    }
-    var fileResult: Result<string> := fs.ReadFile("test.txt");
-    if outcome.Failure? {
-      print fileResult.error, "\n";
-      return;
-    }
-    if fileResult.Success? {
-      print fileResult.value, "\n";
-    }
+    var _ :- fs.CreateFile("test.txt");
+    var _ :- fs.WriteFile("test.txt", "Test dummy file");
+    var contents: string :- fs.ReadFile("test.txt");
+    print contents, "\n";
   }
 
   method Main() {
     TestMyMap();
-    TestMyFilesystem();
+    var outcome: Result<()> := TestMyFilesystem();
+    if outcome.Failure? {
+      print outcome.error, "\n";
+    }
   }
 }

--- a/src/Std.dfy
+++ b/src/Std.dfy
@@ -30,6 +30,19 @@ module Std {
     | Success(value: T)
     | Failure(error: string)
   {
+    predicate method IsFailure() {
+      Failure?
+    }
+    function method PropagateFailure<U>(): Result<U>
+      requires Failure?
+    {
+      Failure(this.error)
+    }
+    function method Extract(): T
+      requires Success?
+    {
+      value
+    }
     function method ToOption(): Option<T> {
       match this
       case Success(s) => Some(s)


### PR DESCRIPTION
Add `IsFailure`, `PropagateFailure`, and `Extract` members to datatype `Result` to make
it usable with `:-` assignments in Dafny.

Update example to use `:-` with `Result`.