### PR TITLE
feat: Add `MapFailure` to `Result`

### DIFF
--- a/src/Wrappers.dfy
+++ b/src/Wrappers.dfy
@@ -63,6 +63,13 @@ module Wrappers {
       Failure(this.error)
     }
 
+    function method MapFailure<NewR>(reWrap: R -> NewR): Result<T, NewR>
+    {
+      match this
+        case Success(s) => Success(s)
+        case Failure(e) => Failure(reWrap(e))
+    }
+
     function method Extract(): T
       requires Success?
     {

--- a/src/Wrappers.dfy
+++ b/src/Wrappers.dfy
@@ -66,8 +66,8 @@ module Wrappers {
     function method MapFailure<NewR>(reWrap: R -> NewR): Result<T, NewR>
     {
       match this
-        case Success(s) => Success(s)
-        case Failure(e) => Failure(reWrap(e))
+      case Success(s) => Success(s)
+      case Failure(e) => Failure(reWrap(e))
     }
 
     function method Extract(): T


### PR DESCRIPTION
For `:-` to work nicely the Failure side of the `Result` needs to line up with the return value.
While this can be simplified by always using the same type,
this is an unresonalb requirement.

This lets custsomers align the `Failure` side of return value.
AlignFailure may also be a good name.

Example

```dafny
  function Foo(): Result<string, int>

  function Bar(): Result<string, string> {
    var fooString :- Foo().MapFailure(_ => "Foo failed.");
    // work
    Success(fooString)
  }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
