### PR TITLE
Make proofs easier for multiple Z3 versions

### DIFF
--- a/src/Collections/Sequences/LittleEndianNat.dfy
+++ b/src/Collections/Sequences/LittleEndianNat.dfy
@@ -181,7 +181,7 @@ abstract module LittleEndianNat {
 
   /* The nat representation of a sequence can be calculated using the nat
   representation of its prefix. */
-  lemma LemmaSeqPrefix(xs: seq<uint>, i: nat)
+  lemma {:vcs_split_on_every_assert} LemmaSeqPrefix(xs: seq<uint>, i: nat)
     requires 0 <= i <= |xs|
     ensures ToNatRight(xs[..i]) + ToNatRight(xs[i..]) * Pow(BASE(), i) == ToNatRight(xs)
   {

--- a/src/Collections/Sequences/LittleEndianNatConversions.dfy
+++ b/src/Collections/Sequences/LittleEndianNatConversions.dfy
@@ -58,8 +58,11 @@ abstract module LittleEndianNatConversions {
     ensures E > 0
   {
     LemmaDivBasicsAuto();
+    assert forall x :: x != 0 ==> 0 / x == 0;
     LemmaPowMultipliesAuto();
     LemmaFundamentalDivMod(Large.BITS(), Small.BITS());
+    assert Large.BITS() == Small.BITS() * (Large.BITS() / Small.BITS()) + (Large.BITS() % Small.BITS());
+    assert (Large.BITS() / Small.BITS()) > 0;
     Large.BITS() / Small.BITS()
   }
 

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -559,6 +559,7 @@ module Seq {
     if |s| == 0 {
     } else {
       LemmaFlattenLengthLeMul(s[..|s|-1], j);
+      assert |FlattenReverse(s[..|s|-1])| <= (|s|-1) * j;
     }
   }
 

--- a/src/NonlinearArithmetic/DivMod.dfy
+++ b/src/NonlinearArithmetic/DivMod.dfy
@@ -1254,7 +1254,7 @@ module DivMod {
     }
   }
 
-  lemma {:timeLimitMultiplier 2} LemmaModNegNeg(x: int, d: int)
+  lemma {:vcs_split_on_every_assert} LemmaModNegNeg(x: int, d: int)
     requires 0 < d
     ensures x % d == (x * (1 - d)) % d
   {

--- a/src/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -124,7 +124,7 @@ module ModInternals {
   }
 
   /* proves the quotient remainder theorem */
-  lemma LemmaQuotientAndRemainder(x: int, q: int, r: int, n: int)
+  lemma {:vcs_split_on_every_assert} LemmaQuotientAndRemainder(x: int, q: int, r: int, n: int)
     requires n > 0
     requires 0 <= r < n
     requires x == q * n + r

--- a/src/NonlinearArithmetic/Power.dfy
+++ b/src/NonlinearArithmetic/Power.dfy
@@ -199,6 +199,26 @@ module Power {
     }
   }
 
+  lemma LemmaPowSubs(b: int, e1: nat, e2: nat)
+    decreases e1
+    requires e1 >= e2
+    ensures Pow(b, e1 - e2) * Pow(b, e2) == Pow(b, e1)
+  {
+    LemmaPowAdds(b, e1 - e2, e2);
+  }
+
+  lemma LemmaPowSubsAuto()
+    ensures forall b: int, e1: nat, e2: nat {:trigger Pow(b, e1 - e2)} | e1 >= e2
+      :: Pow(b, e1 - e2) * Pow(b, e2) == Pow(b, e1)
+  {
+    reveal Pow();
+    forall b: int, e1: nat, e2: nat {:trigger Pow(b, e1 - e2)} | e1 >= e2
+      ensures Pow(b, e1 - e2) * Pow(b, e2) == Pow(b, e1)
+    {
+      LemmaPowSubs(b, e1, e2);
+    }
+  }
+
   /* Subtract exponents when dividing powers. */
   lemma LemmaPowSubtracts(b: nat, e1: nat, e2: nat)
     requires b > 0
@@ -209,7 +229,7 @@ module Power {
     LemmaPowPositiveAuto();
     calc {
       Pow(b, e2) / Pow(b, e1);
-        { LemmaPowAdds(b, e2 - e1, e1); }
+        { LemmaPowSubs(b, e2, e1); }
       Pow(b, e2 - e1) * Pow(b, e1) / Pow(b, e1);
         { LemmaDivByMultiple(Pow(b, e2 - e1), Pow(b, e1)); }
       Pow(b, e2 - e1);
@@ -339,12 +359,7 @@ module Power {
 
     LemmaPowDistributesAuto();
     LemmaPowAddsAuto();
-
-    forall x: int, y: nat, z: nat {:trigger Pow(x, y - z)} | y >= z
-      ensures Pow(x, y - z) * Pow(x, z) == Pow(x, y)
-    {
-      LemmaPowAdds(x, y - z, z);
-    }
+    LemmaPowSubsAuto();
 
     LemmaMulAuto();
     LemmaMulIncreasesAuto();

--- a/src/NonlinearArithmetic/Power.dfy
+++ b/src/NonlinearArithmetic/Power.dfy
@@ -199,7 +199,7 @@ module Power {
     }
   }
 
-  lemma LemmaPowSubs(b: int, e1: nat, e2: nat)
+  lemma LemmaPowSubAddCancel(b: int, e1: nat, e2: nat)
     decreases e1
     requires e1 >= e2
     ensures Pow(b, e1 - e2) * Pow(b, e2) == Pow(b, e1)
@@ -207,15 +207,14 @@ module Power {
     LemmaPowAdds(b, e1 - e2, e2);
   }
 
-  lemma LemmaPowSubsAuto()
+  lemma LemmaPowSubAddCancelAuto()
     ensures forall b: int, e1: nat, e2: nat {:trigger Pow(b, e1 - e2)} | e1 >= e2
       :: Pow(b, e1 - e2) * Pow(b, e2) == Pow(b, e1)
   {
     reveal Pow();
-    forall b: int, e1: nat, e2: nat {:trigger Pow(b, e1 - e2)} | e1 >= e2
-      ensures Pow(b, e1 - e2) * Pow(b, e2) == Pow(b, e1)
+    forall b: int, e1: nat, e2: nat | e1 >= e2
     {
-      LemmaPowSubs(b, e1, e2);
+      LemmaPowSubAddCancel(b, e1, e2);
     }
   }
 
@@ -229,7 +228,7 @@ module Power {
     LemmaPowPositiveAuto();
     calc {
       Pow(b, e2) / Pow(b, e1);
-        { LemmaPowSubs(b, e2, e1); }
+        { LemmaPowSubAddCancel(b, e2, e1); }
       Pow(b, e2 - e1) * Pow(b, e1) / Pow(b, e1);
         { LemmaDivByMultiple(Pow(b, e2 - e1), Pow(b, e1)); }
       Pow(b, e2 - e1);
@@ -359,7 +358,7 @@ module Power {
 
     LemmaPowDistributesAuto();
     LemmaPowAddsAuto();
-    LemmaPowSubsAuto();
+    LemmaPowSubAddCancelAuto();
 
     LemmaMulAuto();
     LemmaMulIncreasesAuto();

--- a/src/Unicode/Utf8EncodingForm.dfy
+++ b/src/Unicode/Utf8EncodingForm.dfy
@@ -232,6 +232,7 @@ module Utf8EncodingForm refines UnicodeEncodingForm {
     var z := (firstByte & 0xF) as bv24;
     var y := (secondByte & 0x3F) as bv24;
     var x := (thirdByte & 0x3F) as bv24;
+    assert {:split_here} true;
     (z << 12) | (y << 6) | x as Unicode.ScalarValue
   }
 
@@ -249,9 +250,7 @@ module Utf8EncodingForm refines UnicodeEncodingForm {
     var z := (secondByte & 0xF) as bv24;
     var y := (thirdByte & 0x3F) as bv24;
     var x := (fourthByte & 0x3F) as bv24;
-    var v := (u1 << 18) | (u2 << 16) | (z << 12) | (y << 6) | x as Unicode.ScalarValue;
     assert {:split_here} true;
-    assert EncodeScalarValueQuadrupleByte(v) == m;
-    v
+    (u1 << 18) | (u2 << 16) | (z << 12) | (y << 6) | x as Unicode.ScalarValue
   }
 }


### PR DESCRIPTION
Tested with these versions:

- 4.8.5
- 4.8.7
- 4.8.8
- 4.8.17
- 4.9.1
- 4.11.0
- 4.11.2

Two proofs fail with 4.8.7, and the whole process takes about twice as long with 4.11.0, but all other versions take around the same amount of time.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
