### PR TITLE
ci: avoid reinstalling dafny-reportgenerator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           dafny-version: "3.4.2"
 
-      - name: Install Dafny report generator
-        run: dotnet tool install --global dafny-reportgenerator
-
       - name: Install lit 
         run: pip install lit OutputCheck
 


### PR DESCRIPTION
As of [setup-dafny-action@v1.5.0](https://github.com/dafny-lang/setup-dafny-action/releases/tag/v1.5.0), dafny-reportgenerator is installed automatically, so our test workflow fails when it also tries to install the tool. This PR removes the installation step from the test workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
