### PR TITLE
Improve durability of a few proofs

### DIFF
--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -649,10 +649,10 @@ module Seq {
     } else {
       calc {
         Filter(f, a + b);
-          { assert (a + b)[0] == a[0]; assert (a + b)[1..] == a[1..] + b; }
+          { assert {:split_here} (a + b)[0] == a[0]; assert (a + b)[1..] == a[1..] + b; }
         Filter(f, [a[0]]) + Filter(f, a[1..] + b);
         Filter(f, [a[0]]) + Filter(f, a[1..]) + Filter(f, b);
-          { assert [(a + b)[0]] + a[1..] + b == a + b; }
+          { assert {:split_here} [(a + b)[0]] + a[1..] + b == a + b; }
         Filter(f, a) + Filter(f, b);
       }
     }

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -563,7 +563,7 @@ module Seq {
     if |s| == 0 {
     } else {
       LemmaFlattenLengthLeMul(s[..|s|-1], j);
-      assert |FlattenReverse(s[..|s|-1])| <= (|s|-1) * j;
+      assert {:split_here} |FlattenReverse(s[..|s|-1])| <= (|s|-1) * j;
     }
   }
 

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -171,7 +171,7 @@ module Seq {
   /* if sequence a and b don't have duplicates and there are no elements in
   common between them, then the concatenated sequence of a + b will not contain
   duplicates either */
-  lemma {:timeLimitMultiplier 3} LemmaNoDuplicatesInConcat<T>(a: seq<T>, b: seq<T>)
+  lemma LemmaNoDuplicatesInConcat<T>(a: seq<T>, b: seq<T>)
     requires HasNoDuplicates(a);
     requires HasNoDuplicates(b);
     requires multiset(a) !! multiset(b);
@@ -180,8 +180,12 @@ module Seq {
     reveal HasNoDuplicates();
     var c := a + b;
     if |c| > 1 {
-      assert forall i, j {:trigger c[i], c[j]}:: i != j && 0 <= i < |a| && |a| <= j < |c| ==>
-        c[i] in multiset(a) && c[j] in multiset(b) && c[i] != c[j]; 
+      assert forall i {:trigger c[i]} :: 0 <= i < |a| ==>
+        c[i] in multiset(a);
+      assert forall j {:trigger c[j]} :: |a| <= j < |c| ==>
+        c[j] in multiset(b);
+      assert forall i, j {:trigger c[i], c[j]} :: i != j && 0 <= i < |a| && |a| <= j < |c| ==>
+        c[i] != c[j];
     }
   }
 


### PR DESCRIPTION
LemmaNoDuplicatesInConcat would fail with certain random seeds, especially with newer Z3 versions. This change proves the result in smaller pieces rather than all in one go. It's arguably more readable, too.

LemmaFlattenLengthLeMul and LemmaFilterDistributesOverConcat also sometimes timed out or failed, but a few instances of `{:split_here}` seem to solve those issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
