### PR TITLE
Adapt some proofs for lower variability and better compatibility with Z3 4.12.1

### DIFF
--- a/examples/Collections/Arrays/BinarySearch.dfy
+++ b/examples/Collections/Arrays/BinarySearch.dfy
@@ -31,6 +31,7 @@ module BinarySearchExamples {
     var sortedInput := MergeSortBy(input, (x, y) => x <= y);
     print sortedInput, "\n";
 
+    assert SortedBy(sortedInput, (x, y) => x <= y);
     var sortedArray := ToArray(sortedInput);
     SortedByLessThanOrEqualTo(sortedArray[..]);
     var indexOfThree := BinarySearch.BinarySearch(sortedArray, 3, (x, y) => x < y);

--- a/src/Collections/Sequences/LittleEndianNat.dfy
+++ b/src/Collections/Sequences/LittleEndianNat.dfy
@@ -254,6 +254,7 @@ abstract module {:options "-functionSyntax:4"} LittleEndianNat {
       } else {
         LemmaSeqMswInequality(ys[..i+1], xs[..i+1]);
       }
+      assert ToNatRight(xs[..i+1]) != ToNatRight(ys[..i+1]);
       LemmaSeqPrefixNeq(xs, ys, i + 1);
     }
   }

--- a/src/Collections/Sequences/LittleEndianNat.dfy
+++ b/src/Collections/Sequences/LittleEndianNat.dfy
@@ -318,7 +318,7 @@ abstract module {:options "-functionSyntax:4"} LittleEndianNat {
         reveal ToNatRight();
         calc ==> {
           true;
-            { LemmaModEquivalenceAuto(); }
+            { LemmaModEquivalence(ToNatRight(xs), ToNatRight(DropFirst(xs)) * BASE() + First(xs), BASE()); }
           IsModEquivalent(ToNatRight(xs), ToNatRight(DropFirst(xs)) * BASE() + First(xs), BASE());
             { LemmaModMultiplesBasicAuto(); }
           IsModEquivalent(ToNatRight(xs), First(xs), BASE());
@@ -504,7 +504,7 @@ abstract module {:options "-functionSyntax:4"} LittleEndianNat {
 
   /* SeqAdd returns the same value as converting the sequences to nats, then
   adding them. */
-  lemma LemmaSeqAdd(xs: seq<uint>, ys: seq<uint>, zs: seq<uint>, cout: nat)
+  lemma {:vcs_split_on_every_assert} LemmaSeqAdd(xs: seq<uint>, ys: seq<uint>, zs: seq<uint>, cout: nat)
     requires |xs| == |ys|
     requires SeqAdd(xs, ys) == (zs, cout)
     ensures ToNatRight(xs) + ToNatRight(ys) == ToNatRight(zs) + cout * Pow(BASE(), |xs|)
@@ -528,7 +528,7 @@ abstract module {:options "-functionSyntax:4"} LittleEndianNat {
           { LemmaSeqAdd(DropLast(xs), DropLast(ys), zs', cin); }
         ToNatLeft(DropLast(xs)) + ToNatLeft(DropLast(ys)) - cin * pow + z * pow;
           {
-            LemmaMulEqualityAuto();
+            LemmaMulEquality(sum, z + cout * BASE(), pow);
             assert sum * pow == (z + cout * BASE()) * pow;
             LemmaMulIsDistributiveAuto();
           } 
@@ -561,7 +561,7 @@ abstract module {:options "-functionSyntax:4"} LittleEndianNat {
 
   /* SeqSub returns the same value as converting the sequences to nats, then
   subtracting them. */
-  lemma LemmaSeqSub(xs: seq<uint>, ys: seq<uint>, zs: seq<uint>, cout: nat)
+  lemma {:vcs_split_on_every_assert} LemmaSeqSub(xs: seq<uint>, ys: seq<uint>, zs: seq<uint>, cout: nat)
     requires |xs| == |ys|
     requires SeqSub(xs, ys) == (zs, cout)
     ensures ToNatRight(xs) - ToNatRight(ys) + cout * Pow(BASE(), |xs|) == ToNatRight(zs)
@@ -586,7 +586,7 @@ abstract module {:options "-functionSyntax:4"} LittleEndianNat {
           { LemmaSeqSub(DropLast(xs), DropLast(ys), zs', cin); }
         ToNatLeft(DropLast(xs)) - ToNatLeft(DropLast(ys)) + cin * pow + z * pow;
           {
-            LemmaMulEqualityAuto();
+            LemmaMulEquality(cout * BASE() + Last(xs) - cin - Last(ys), z, pow);
             assert pow * (cout * BASE() + Last(xs) - cin - Last(ys)) == pow * z;
             LemmaMulIsDistributiveAuto();
           }

--- a/src/Collections/Sequences/LittleEndianNat.dfy
+++ b/src/Collections/Sequences/LittleEndianNat.dfy
@@ -254,7 +254,7 @@ abstract module {:options "-functionSyntax:4"} LittleEndianNat {
       } else {
         LemmaSeqMswInequality(ys[..i+1], xs[..i+1]);
       }
-      assert ToNatRight(xs[..i+1]) != ToNatRight(ys[..i+1]);
+      reveal ToNatRight();
       LemmaSeqPrefixNeq(xs, ys, i + 1);
     }
   }

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -677,13 +677,13 @@ module {:options "-functionSyntax:4"} Seq {
       assert xs + ys == ys;
     } else {
       calc {
-        Filter(f, a + b);
-          { assert {:split_here} (a + b)[0] == a[0]; assert (a + b)[1..] == a[1..] + b; }
-        Filter(f, [a[0]]) + Filter(f, a[1..] + b);
-          { assert Filter(f, a[1..] + b) == Filter(f, a[1..]) + Filter(f, b); }
-        Filter(f, [a[0]]) + (Filter(f, a[1..]) + Filter(f, b));
-          { assert {:split_here} [(a + b)[0]] + (a[1..] + b) == a + b; }
-        Filter(f, a) + Filter(f, b);
+        Filter(f, xs + ys);
+          { assert {:split_here} (xs + ys)[0] == xs[0]; assert (xs + ys)[1..] == xs[1..] + ys; }
+        Filter(f, [xs[0]]) + Filter(f, xs[1..] + ys);
+          { assert Filter(f, xs[1..] + ys) == Filter(f, xs[1..]) + Filter(f, ys); }
+        Filter(f, [xs[0]]) + (Filter(f, xs[1..]) + Filter(f, ys));
+          { assert {:split_here} [(xs + ys)[0]] + (xs[1..] + ys) == xs + ys; }
+        Filter(f, xs) + Filter(f, ys);
       }
     }
   }

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -655,8 +655,9 @@ module {:options "-functionSyntax:4"} Seq {
         Filter(f, a + b);
           { assert {:split_here} (a + b)[0] == a[0]; assert (a + b)[1..] == a[1..] + b; }
         Filter(f, [a[0]]) + Filter(f, a[1..] + b);
-        Filter(f, [a[0]]) + Filter(f, a[1..]) + Filter(f, b);
-          { assert {:split_here} [(a + b)[0]] + a[1..] + b == a + b; }
+          { assert Filter(f, a[1..] + b) == Filter(f, a[1..]) + Filter(f, b); }
+        Filter(f, [a[0]]) + (Filter(f, a[1..]) + Filter(f, b));
+          { assert {:split_here} [(a + b)[0]] + (a[1..] + b) == a + b; }
         Filter(f, a) + Filter(f, b);
       }
     }

--- a/src/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -112,6 +112,8 @@ module {:options "-functionSyntax:4"} ModInternals {
     requires n > 0
     ensures (x + n) % n == x % n
   {
+    LemmaFundamentalDivMod(x, n);
+    LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
     forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
@@ -122,6 +124,8 @@ module {:options "-functionSyntax:4"} ModInternals {
     requires n > 0
     ensures (x - n) % n == x % n
   {
+    LemmaFundamentalDivMod(x, n);
+    LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
     forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }

--- a/src/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -84,6 +84,62 @@ module {:options "-functionSyntax:4"} ModInternals {
     }
   }
 
+  lemma LemmaDivAddDenominator(n: int, x: int)
+    requires n > 0
+    ensures (x + n) / n == x / n + 1
+  {
+    LemmaFundamentalDivMod(x, n);
+    LemmaFundamentalDivMod(x + n, n);
+    var zp := (x + n) / n - x / n - 1;
+    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
+    if (zp > 0) { LemmaMulInequality(1, zp, n); }
+    if (zp < 0) { LemmaMulInequality(zp, -1, n); }
+  }
+
+  lemma LemmaDivSubDenominator(n: int, x: int)
+    requires n > 0
+    ensures (x - n) / n == x / n - 1
+  {
+    LemmaFundamentalDivMod(x, n);
+    LemmaFundamentalDivMod(x - n, n);
+    var zm := (x - n) / n - x / n + 1;
+    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
+    if (zm > 0) { LemmaMulInequality(1, zm, n); }
+    if (zm < 0) { LemmaMulInequality(zm, -1, n); }
+  }
+
+  lemma LemmaModAddDenominator(n: int, x: int)
+    requires n > 0
+    ensures (x + n) % n == x % n
+  {
+    var zp := (x + n) / n - x / n - 1;
+    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
+    if (zp > 0) { LemmaMulInequality(1, zp, n); }
+    if (zp < 0) { LemmaMulInequality(zp, -1, n); }
+  }
+
+  lemma LemmaModSubDenominator(n: int, x: int)
+    requires n > 0
+    ensures (x - n) % n == x % n
+  {
+    var zm := (x - n) / n - x / n + 1;
+    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
+    if (zm > 0) { LemmaMulInequality(1, zm, n); }
+    if (zm < 0) { LemmaMulInequality(zm, -1, n); }
+  }
+
+  lemma LemmaModBelowDenominator(n: int, x: int)
+    requires n > 0
+    ensures 0 <= x < n <==> x % n == x
+  {
+    forall x: int
+      ensures 0 <= x < n <==> x % n == x
+    {
+      if (0 <= x < n) { LemmaSmallMod(x, n); }
+      LemmaModRange(x, n);
+    }
+  }
+
   /* proves the basics of the modulus operation */
   lemma LemmaModBasics(n: int)
     requires n > 0
@@ -94,32 +150,17 @@ module {:options "-functionSyntax:4"} ModInternals {
     ensures  forall x: int {:trigger x % n} :: 0 <= x < n <==> x % n == x
   {
     forall x: int
-      ensures 0 <= x < n <==> x % n == x
-    {
-      if (0 <= x < n) { LemmaSmallMod(x, n); }
-      LemmaModRange(x, n);
-    }
-    forall x: int
       ensures (x + n) % n == x % n
       ensures (x - n) % n == x % n
       ensures (x + n) / n == x / n + 1
       ensures (x - n) / n == x / n - 1
+      ensures 0 <= x < n <==> x % n == x
     {
-      LemmaFundamentalDivMod(x, n);
-      LemmaFundamentalDivMod(x + n, n);
-      LemmaFundamentalDivMod(x - n, n);
-      LemmaModRange(x, n);
-      LemmaModRange(x + n, n);
-      LemmaModRange(x - n, n);
-      var zp := (x + n) / n - x / n - 1;
-      var zm := (x - n) / n - x / n + 1;
-      forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
-      forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
-      if (zp > 0) { LemmaMulInequality(1, zp, n); }
-      if (zp < 0) { LemmaMulInequality(zp, -1, n); }
-      if (zp == 0) { LemmaMulBasicsAuto(); }
-      if (zm > 0) { LemmaMulInequality(1, zm, n); }
-      if (zm < 0) { LemmaMulInequality(zm, -1, n); }
+      LemmaModBelowDenominator(n, x);
+      LemmaModAddDenominator(n, x);
+      LemmaModSubDenominator(n, x);
+      LemmaDivAddDenominator(n, x);
+      LemmaDivSubDenominator(n, x);
     }
   }
 
@@ -133,15 +174,16 @@ module {:options "-functionSyntax:4"} ModInternals {
     decreases if q > 0 then q else -q
   {
     LemmaModBasics(n);
-    LemmaMulIsCommutativeAuto();
-    LemmaMulIsDistributiveAddAuto();
-    LemmaMulIsDistributiveSubAuto();
 
     if q > 0 {
+      MulInternalsNonlinear.LemmaMulIsDistributiveAdd(n, q - 1, 1);
+      LemmaMulIsCommutativeAuto();
       assert q * n + r == (q - 1) * n + n + r;
       LemmaQuotientAndRemainder(x - n, q - 1, r, n);
     }
     else if q < 0 {
+      Mul.LemmaMulIsDistributiveSub(n, q + 1, 1);
+      LemmaMulIsCommutativeAuto();
       assert q * n + r == (q + 1) * n - n + r;
       LemmaQuotientAndRemainder(x + n, q + 1, r, n);
     }


### PR DESCRIPTION
This makes several proofs more explicit to reduce their variability and make them succeed with Z3 4.12.1.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
