### PR TITLE
Fix "--include" typo

### DIFF
--- a/src/FileIO/README.md
+++ b/src/FileIO/README.md
@@ -21,10 +21,10 @@ For example, to run a `Program.dfy` file that depends on the `FileIO` module, ru
 $ dafny run Program.dfy --include libraries/src/FileIO/FileIO.cs
 
 # Java
-$ dafny run Program.dfy --target:java --include libraries/src/FileIO/FileIO.java
+$ dafny run Program.dfy --target:java --input libraries/src/FileIO/FileIO.java
 
 # Javascript
-$ dafny run Program.dfy --target:js --include libraries/src/FileIO/FileIO.js
+$ dafny run Program.dfy --target:js --input libraries/src/FileIO/FileIO.js
 ```
 
 (If you aren't using `dafny run` to run your program,

--- a/src/FileIO/README.md
+++ b/src/FileIO/README.md
@@ -18,7 +18,7 @@ For example, to run a `Program.dfy` file that depends on the `FileIO` module, ru
 
 ```bash
 # C#/.NET
-$ dafny run Program.dfy --include libraries/src/FileIO/FileIO.cs
+$ dafny run Program.dfy --input libraries/src/FileIO/FileIO.cs
 
 # Java
 $ dafny run Program.dfy --target:java --input libraries/src/FileIO/FileIO.java

--- a/src/Relations.dfy
+++ b/src/Relations.dfy
@@ -55,4 +55,39 @@ module {:options "-functionSyntax:4"} Relations {
     requires TotalOrdering(lessThan)
     ensures SortedBy([x] + s, lessThan)
   {}  
+
+  /* An element in an ordered set is called minimal, if it is less than every element of the set. */
+  ghost predicate IsMinimum<T>(R: (T, T) -> bool, m: T, s: set<T>) 
+  {
+    m in s && forall y: T | y in s :: R(m, y)
+  }
+
+  /* Any totally ordered set contains a unique minimal element. */
+  lemma LemmaUniqueMinimum<T(!new)>(R: (T, T) -> bool, s: set<T>) 
+    requires &&|s| > 0 
+             && TotalOrdering(R)
+    ensures && (exists m: T :: IsMinimum(R, m, s))
+            && (forall m, n: T :: IsMinimum(R, m, s) && IsMinimum(R, n, s) ==> m == n)
+  {
+    var x :| x in s;
+    if s == {x} {
+      assert IsMinimum(R, x, s);
+    } else {
+      var s' := s - {x};
+      LemmaUniqueMinimum(R, s');
+      var z :| IsMinimum(R, z, s');
+      if 
+      case R(z, x) => {
+        forall y: T | y in s ensures R(z, y) {
+        }
+        assert IsMinimum(R, z, s); 
+      }
+      case R(x, z) => {
+        forall y: T | y in s ensures R(x, y) {
+        }
+        assert IsMinimum(R, x, s); 
+      }
+    assert exists m: T :: IsMinimum(R, m, s);
+    }
+  }
 }

--- a/src/Relations.dfy
+++ b/src/Relations.dfy
@@ -76,39 +76,4 @@ module {:options "-functionSyntax:4"} Relations {
     requires TotalOrdering(lessThan)
     ensures SortedBy([x] + s, lessThan)
   {}  
-
-  /* An element in an ordered set is called minimal, if it is less than every element of the set. */
-  ghost predicate IsMinimum<T>(R: (T, T) -> bool, m: T, s: set<T>) 
-  {
-    m in s && forall y: T | y in s :: R(m, y)
-  }
-
-  /* Any totally ordered set contains a unique minimal element. */
-  lemma LemmaUniqueMinimum<T(!new)>(R: (T, T) -> bool, s: set<T>) 
-    requires &&|s| > 0 
-             && TotalOrdering(R)
-    ensures && (exists m: T :: IsMinimum(R, m, s))
-            && (forall m, n: T :: IsMinimum(R, m, s) && IsMinimum(R, n, s) ==> m == n)
-  {
-    var x :| x in s;
-    if s == {x} {
-      assert IsMinimum(R, x, s);
-    } else {
-      var s' := s - {x};
-      LemmaUniqueMinimum(R, s');
-      var z :| IsMinimum(R, z, s');
-      if 
-      case R(z, x) => {
-        forall y: T | y in s ensures R(z, y) {
-        }
-        assert IsMinimum(R, z, s); 
-      }
-      case R(x, z) => {
-        forall y: T | y in s ensures R(x, y) {
-        }
-        assert IsMinimum(R, x, s); 
-      }
-    assert exists m: T :: IsMinimum(R, m, s);
-    }
-  }
 }


### PR DESCRIPTION
The reference [manual](http://dafny.org/dafny/DafnyRef/DafnyRef) doesn't include an `--include` option. I believe this should be `--input`.



By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
