### PR TITLE
Fix JSON proof instability

### DIFF
--- a/src/JSON/ZeroCopy/Deserializer.dfy
+++ b/src/JSON/ZeroCopy/Deserializer.dfy
@@ -413,8 +413,8 @@ module {:options "-functionSyntax:4"} JSON.ZeroCopy.Deserializer {
         var v := Grammar.Object(obj);
         var sp := SP(v, cs');
         assert sp.StrictlySplitFrom?(cs, Spec.Value) by {
-          assert SP(obj, cs').StrictlySplitFrom?(cs, Spec.Object);
           Spec.UnfoldValueObject(v);
+          assert SP(obj, cs').StrictlySplitFrom?(cs, Spec.Object);
         }
         Success(sp)
       else if c == '[' as opt_byte then
@@ -668,7 +668,7 @@ module {:options "-functionSyntax:4"} JSON.ZeroCopy.Deserializer {
   module Arrays refines Sequences {
     import opened Params = ArrayParams
 
-    lemma BracketedToArray(arr: jarray)
+    lemma {:vcs_split_on_every_assert} BracketedToArray(arr: jarray)
       ensures Spec.Bracketed(arr, SuffixedElementSpec) == Spec.Array(arr)
     {
       var rItem := (d: jitem) requires d < arr => Spec.Item(d);

--- a/src/JSON/ZeroCopy/Deserializer.dfy
+++ b/src/JSON/ZeroCopy/Deserializer.dfy
@@ -416,6 +416,7 @@ module {:options "-functionSyntax:4"} JSON.ZeroCopy.Deserializer {
           Spec.UnfoldValueObject(v);
           assert SP(obj, cs').StrictlySplitFrom?(cs, Spec.Object);
         }
+        Spec.UnfoldValueObject(v);
         Success(sp)
       else if c == '[' as opt_byte then
         var SP(arr, cs') :- Arrays.Array(cs, ValueParser(cs));

--- a/src/JSON/ZeroCopy/Serializer.dfy
+++ b/src/JSON/ZeroCopy/Serializer.dfy
@@ -99,7 +99,6 @@ module {:options "-functionSyntax:4"} JSON.ZeroCopy.Serializer {
               else wr;
     assert wr.Bytes() == writer.Bytes() + Spec.View(num.minus) + Spec.View(num.num) + Spec.Maybe(num.frac, Spec.Frac) + Spec.Maybe(num.exp, Spec.Exp) by {
       if num.exp.NonEmpty? {} else {
-        assert wr.Bytes() == writer.Bytes() + Spec.View(num.minus) + Spec.View(num.num) + Spec.Maybe(num.frac, Spec.Frac);
         assert wr.Bytes() == writer.Bytes() + Spec.View(num.minus) + Spec.View(num.num) + Spec.Maybe(num.frac, Spec.Frac) + [];
       }
     }


### PR DESCRIPTION
`src/JSON/ZeroCopy/Deserializer.dfy` and `src/JSON/ZeroCopy/Serializer.dfy` verified in 4.0, but not in 4.1. This PR fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
