### PR TITLE
fix: Partially fix nightly build for 4.2

### DIFF
--- a/.github/workflows/check-examples-in-docs.yml
+++ b/.github/workflows/check-examples-in-docs.yml
@@ -11,7 +11,6 @@ concurrency:
 
 jobs:
   check-examples-in-docs:
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   reusable_verification:
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/lit.site.cfg
+++ b/lit.site.cfg
@@ -116,7 +116,7 @@ newDafnyArgs = [
 '--cores=2',
 
 # Set a default time limit, to catch cases where verification time runs off the rails
-'--verification-time-limit=600'
+'--verification-time-limit=300'
 ]
 
 # Add standard parameters
@@ -145,12 +145,12 @@ else:
     standardTranslationArguments = ''
 
 resolveArgs = ' resolve --use-basename-for-filename ' + standardArguments
-verifyArgs = ' verify --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments
-buildArgs = ' build --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments + ' ' + standardTranslationArguments
-runArgs = ' run --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments + ' ' + standardTranslationArguments
-testArgs = ' test --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments + ' ' + standardTranslationArguments
+verifyArgs = ' verify --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments
+buildArgs = ' build --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
+runArgs = ' run --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
+testArgs = ' test --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
 
-config.substitutions.append( ('%trargs', '--use-basename-for-filename --cores:2 --verification-time-limit:600' ) )
+config.substitutions.append( ('%trargs', '--use-basename-for-filename --cores:2 --verification-time-limit:300' ) )
 
 config.substitutions.append( ('%resolve', dafnyExecutable + resolveArgs ) )
 config.substitutions.append( ('%verify', dafnyExecutable + verifyArgs ) )

--- a/lit.site.cfg
+++ b/lit.site.cfg
@@ -116,7 +116,7 @@ newDafnyArgs = [
 '--cores=2',
 
 # Set a default time limit, to catch cases where verification time runs off the rails
-'--verification-time-limit=300'
+'--verification-time-limit=600'
 ]
 
 # Add standard parameters
@@ -145,12 +145,12 @@ else:
     standardTranslationArguments = ''
 
 resolveArgs = ' resolve --use-basename-for-filename ' + standardArguments
-verifyArgs = ' verify --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments
-buildArgs = ' build --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
-runArgs = ' run --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
-testArgs = ' test --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
+verifyArgs = ' verify --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments
+buildArgs = ' build --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments + ' ' + standardTranslationArguments
+runArgs = ' run --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments + ' ' + standardTranslationArguments
+testArgs = ' test --use-basename-for-filename --cores:2 --verification-time-limit:600 ' + standardArguments + ' ' + standardTranslationArguments
 
-config.substitutions.append( ('%trargs', '--use-basename-for-filename --cores:2 --verification-time-limit:300' ) )
+config.substitutions.append( ('%trargs', '--use-basename-for-filename --cores:2 --verification-time-limit:600' ) )
 
 config.substitutions.append( ('%resolve', dafnyExecutable + resolveArgs ) )
 config.substitutions.append( ('%verify', dafnyExecutable + verifyArgs ) )

--- a/lit.site.cfg
+++ b/lit.site.cfg
@@ -7,6 +7,7 @@ import sys
 import re
 import platform
 import shutil
+import subprocess
 from os import path
 
 import lit.util
@@ -136,11 +137,18 @@ def buildCmd(args):
 
 standardArguments = addParams(' '.join([]))
 
+# Pass --compile-suffix when available (since extern implementations depend on this)
+dafnyHelpProcess = subprocess.run(['dafny', '/help'], capture_output=True)
+if dafnyHelpProcess.stdout.find(b'/compileSuffix') != -1:
+    standardTranslationArguments = ' '.join(['--compile-suffix'])
+else:
+    standardTranslationArguments = ''
+
 resolveArgs = ' resolve --use-basename-for-filename ' + standardArguments
 verifyArgs = ' verify --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments
-buildArgs = ' build --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments
-runArgs = ' run --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments
-testArgs = ' test --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments
+buildArgs = ' build --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
+runArgs = ' run --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
+testArgs = ' test --use-basename-for-filename --cores:2 --verification-time-limit:300 ' + standardArguments + ' ' + standardTranslationArguments
 
 config.substitutions.append( ('%trargs', '--use-basename-for-filename --cores:2 --verification-time-limit:300' ) )
 


### PR DESCRIPTION
Only fixes the fact that the top-level workflow looks green even though the job fails (https://github.com/dafny-lang/libraries/actions/runs/5506948866) and adds `--compile-suffix` when necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
