### PR TITLE
fix: Add missing type characteristics

### DIFF
--- a/examples/BinaryOperations.dfy
+++ b/examples/BinaryOperations.dfy
@@ -161,7 +161,7 @@ module {:options "-functionSyntax:4"} HomomorphismExamples {
   import IntegersExample
   import RealsExample
 
-  lemma IdentityIsHomomorphism<T>(bop: (T, T) -> T)
+  lemma IdentityIsHomomorphism<T(!new)>(bop: (T, T) -> T)
     ensures IsHomomorphism(bop, bop, x => x)
   {}
 
@@ -169,7 +169,7 @@ module {:options "-functionSyntax:4"} HomomorphismExamples {
     ensures IsHomomorphism(IntegersExample.add, RealsExample.add, (x: int) => x as real)
   {}
 
-  lemma ConstUnitIsHomomorphism<S,T>(bop1: (S, S) -> S, bop2: (T, T) -> T, unit: T)
+  lemma ConstUnitIsHomomorphism<S(!new), T(!new)>(bop1: (S, S) -> S, bop2: (T, T) -> T, unit: T)
     requires IsUnital(bop2, unit)
     ensures IsHomomorphism(bop1, bop2, x => unit)
   {}

--- a/examples/RelationsExamples.dfy
+++ b/examples/RelationsExamples.dfy
@@ -23,19 +23,19 @@ module {:options "-functionSyntax:4"} RelationsExamples {
     requires n >= 1
     ensures EquivalenceRelation(R)
   {
-    (x, y) => (x % n ==  y % n)
+    (x, y) => x % n ==  y % n
   }
 
   lemma BuiltInIntEqIsEquivalenceRelation()
-    ensures EquivalenceRelation((x: int, y: int) => (x == y))
+    ensures EquivalenceRelation((x: int, y: int) => x == y)
   {}
 
   lemma BuiltInIntGeIsAntiSymmetricRelation()
-    ensures AntiSymmetric((x: int, y: int) => (x >= y))
+    ensures AntiSymmetric((x: int, y: int) => x >= y)
   {}
 
   lemma BuiltInIntLtIsAsymmetricRelation()
-    ensures Asymmetric((x: int, y: int) => (x < y))
+    ensures Asymmetric((x: int, y: int) => x < y)
   {
   }
 
@@ -48,22 +48,22 @@ module {:options "-functionSyntax:4"} RelationsExamples {
   }
 
   lemma BuiltInIntLtIsNotReflexiveRelation()
-    ensures !Reflexive((x: int, y: int) => (x < y))
+    ensures !Reflexive((x: int, y: int) => x < y)
   {
-    var f := (x: int, y: int) => (x < y);
+    var f := (x: int, y: int) => x < y;
     assert !f(0, 0);
     assert !forall x: int :: f(x, x);
     assert !Reflexive(f);
   }
 
   lemma BuiltInIntLtIsIrreflexiveRelation()
-    ensures Irreflexive((x: int, y: int) => (x < y))
+    ensures Irreflexive((x: int, y: int) => x < y)
   {}
 
   lemma BuiltInIntEqIsNotIrreflexiveRelation()
-    ensures !Irreflexive((x: int, y: int) => (x == y))
+    ensures !Irreflexive((x: int, y: int) => x == y)
   {
-    var f := (x: int, y: int) => (x == y);
+    var f := (x: int, y: int) => x == y;
     assert f(0, 0);
     assert !Irreflexive(f);
   }

--- a/examples/RelationsExamples.dfy
+++ b/examples/RelationsExamples.dfy
@@ -51,8 +51,8 @@ module {:options "-functionSyntax:4"} RelationsExamples {
     ensures !Reflexive((x: int, y: int) => (x < y))
   {
     var f := (x: int, y: int) => (x < y);
-    assert !f(0,0);
-    assert !forall x: int :: f(x,x);
+    assert !f(0, 0);
+    assert !forall x: int :: f(x, x);
     assert !Reflexive(f);
   }
 
@@ -64,7 +64,7 @@ module {:options "-functionSyntax:4"} RelationsExamples {
     ensures !Irreflexive((x: int, y: int) => (x == y))
   {
     var f := (x: int, y: int) => (x == y);
-    assert f(0,0);
+    assert f(0, 0);
     assert !Irreflexive(f);
   }
 

--- a/examples/RelationsExamples.dfy
+++ b/examples/RelationsExamples.dfy
@@ -68,11 +68,11 @@ module {:options "-functionSyntax:4"} RelationsExamples {
     assert !Irreflexive(f);
   }
 
-  lemma AsymmetricIsAntiSymmetric<T>(f: (T,T)->bool)
+  lemma AsymmetricIsAntiSymmetric<T(!new)>(f: (T, T) -> bool)
     ensures Asymmetric(f) ==> AntiSymmetric(f)
   {}
 
-  lemma AsymmetricIsIrreflexive<T>(f: (T,T)->bool)
+  lemma AsymmetricIsIrreflexive<T(!new)>(f: (T, T) -> bool)
     ensures Asymmetric(f) ==> Irreflexive(f)
   {}
 }

--- a/src/Collections/Arrays/BinarySearch.dfy
+++ b/src/Collections/Arrays/BinarySearch.dfy
@@ -12,7 +12,7 @@ module BinarySearch {
   import opened Wrappers
   import opened Relations
 
-  method BinarySearch<T>(a: array<T>, key: T, less: (T, T) -> bool) returns (r: Option<nat>)
+  method BinarySearch<T(!new)>(a: array<T>, key: T, less: (T, T) -> bool) returns (r: Option<nat>)
     requires SortedBy(a[..], (x, y) => less(x, y) || x == y)
     requires StrictTotalOrdering(less)
     ensures r.Some? ==> r.value < a.Length && a[r.value] == key

--- a/src/Collections/Sequences/MergeSort.dfy
+++ b/src/Collections/Sequences/MergeSort.dfy
@@ -12,7 +12,7 @@ module {:options "-functionSyntax:4"} Seq.MergeSort {
   import opened Relations
 
   //Splits a sequence in two, sorts the two subsequences using itself, and merge the two sorted sequences using `MergeSortedWith`
-  function MergeSortBy<T>(a: seq<T>, lessThanOrEq: (T, T) -> bool): (result :seq<T>)
+  function MergeSortBy<T(!new)>(a: seq<T>, lessThanOrEq: (T, T) -> bool): (result :seq<T>)
     requires TotalOrdering(lessThanOrEq)
     ensures multiset(a) == multiset(result)
     ensures SortedBy(result, lessThanOrEq)
@@ -31,7 +31,7 @@ module {:options "-functionSyntax:4"} Seq.MergeSort {
       MergeSortedWith(leftSorted, rightSorted, lessThanOrEq)
   }
 
-  function {:tailrecursion} MergeSortedWith<T>(left: seq<T>, right: seq<T>, lessThanOrEq: (T, T) -> bool) : (result :seq<T>)
+  function {:tailrecursion} MergeSortedWith<T(!new)>(left: seq<T>, right: seq<T>, lessThanOrEq: (T, T) -> bool) : (result :seq<T>)
     requires SortedBy(left, lessThanOrEq)
     requires SortedBy(right, lessThanOrEq)
     requires TotalOrdering(lessThanOrEq)

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -752,11 +752,11 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* inv(b, xs) ==> inv(FoldLeft(f, b, xs), []). */
-  lemma LemmaInvFoldLeft<A,B>(inv: (B, seq<A>) -> bool,
-                              stp: (B, A, B) -> bool,
-                              f: (B, A) -> B,
-                              b: B,
-                              xs: seq<A>)
+  lemma LemmaInvFoldLeft<A(!new), B(!new)>(inv: (B, seq<A>) -> bool,
+                                           stp: (B, A, B) -> bool,
+                                           f: (B, A) -> B,
+                                           b: B,
+                                           xs: seq<A>)
     requires InvFoldLeft(inv, stp)
     requires forall b, a :: stp(b, a, f(b, a))
     requires inv(b, xs)
@@ -810,11 +810,11 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* inv([], b) ==> inv(xs, FoldRight(f, xs, b)) */
-  lemma LemmaInvFoldRight<A,B>(inv: (seq<A>, B) -> bool,
-                               stp: (A, B, B) -> bool,
-                               f: (A, B) -> B,
-                               b: B,
-                               xs: seq<A>)
+  lemma LemmaInvFoldRight<A(!new), B(!new)>(inv: (seq<A>, B) -> bool,
+                                            stp: (A, B, B) -> bool,
+                                            f: (A, B) -> B,
+                                            b: B,
+                                            xs: seq<A>)
     requires InvFoldRight(inv, stp)
     requires forall a, b :: stp(a, b, f(a, b))
     requires inv([], b)
@@ -876,7 +876,7 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* Proves that any two sequences that are sorted by a total order and that have the same elements are equal. */
-  lemma SortedUnique<T>(xs: seq<T>, ys: seq<T>, R: (T, T) -> bool)
+  lemma SortedUnique<T(!new)>(xs: seq<T>, ys: seq<T>, R: (T, T) -> bool)
     requires SortedBy(xs, R)
     requires SortedBy(ys, R)
     requires TotalOrdering(R)
@@ -896,7 +896,7 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* Converts a set to a sequence that is ordered w.r.t. a given total order. */
-  function SetToSortedSeq<T>(s: set<T>, R: (T, T) -> bool): (xs: seq<T>)
+  function SetToSortedSeq<T(!new)>(s: set<T>, R: (T, T) -> bool): (xs: seq<T>)
     requires TotalOrdering(R)
     ensures multiset(s) == multiset(xs)
     ensures SortedBy(xs, R)

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -653,7 +653,7 @@ module {:options "-functionSyntax:4"} Seq {
   /* Applying a function to a sequence  is distributive over concatenation. That is, concatenating 
      two sequences and then applying Map is the same as applying Map to each sequence separately, 
      and then concatenating the two resulting sequences. */
-  lemma {:opaque} LemmaMapDistributesOverConcat<T, R>(f: (T ~> R), xs: seq<T>, ys: seq<T>)
+  lemma LemmaMapDistributesOverConcat<T, R>(f: (T ~> R), xs: seq<T>, ys: seq<T>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     requires forall j :: 0 <= j < |ys| ==> f.requires(ys[j])
     ensures Map(f, xs + ys) == Map(f, xs) + Map(f, ys)
@@ -688,7 +688,7 @@ module {:options "-functionSyntax:4"} Seq {
   /* Filtering a sequence is distributive over concatenation. That is, concatenating two sequences 
      and then using "Filter" is the same as using "Filter" on each sequence separately, and then 
      concatenating the two resulting sequences. */
-  lemma {:opaque} LemmaFilterDistributesOverConcat<T>(f: (T ~> bool), xs: seq<T>, ys: seq<T>)
+  lemma LemmaFilterDistributesOverConcat<T>(f: (T ~> bool), xs: seq<T>, ys: seq<T>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     requires forall j :: 0 <= j < |ys| ==> f.requires(ys[j])
     ensures Filter(f, xs + ys) == Filter(f, xs) + Filter(f, ys)
@@ -720,7 +720,7 @@ module {:options "-functionSyntax:4"} Seq {
   /* Folding to the left is distributive over concatenation. That is, concatenating two 
      sequences and then folding them to the left, is the same as folding to the left the 
      first sequence and using the result to fold to the left the second sequence. */
-  lemma {:opaque} LemmaFoldLeftDistributesOverConcat<A, T>(f: (A, T) -> A, init: A, xs: seq<T>, ys: seq<T>)
+  lemma LemmaFoldLeftDistributesOverConcat<A, T>(f: (A, T) -> A, init: A, xs: seq<T>, ys: seq<T>)
     requires 0 <= |xs + ys|
     ensures FoldLeft(f, init, xs + ys) == FoldLeft(f, FoldLeft(f, init, xs), ys)
   {
@@ -781,7 +781,7 @@ module {:options "-functionSyntax:4"} Seq {
   /* Folding to the right is (contravariantly) distributive over concatenation. That is, concatenating
      two sequences and then folding them to the right, is the same as folding to the right 
      the second sequence and using the result to fold to the right the first sequence. */
-  lemma {:opaque} LemmaFoldRightDistributesOverConcat<A, T>(f: (T, A) -> A, init: A, xs: seq<T>, ys: seq<T>)
+  lemma LemmaFoldRightDistributesOverConcat<A, T>(f: (T, A) -> A, init: A, xs: seq<T>, ys: seq<T>)
     requires 0 <= |xs + ys|
     ensures FoldRight(f, xs + ys, init) == FoldRight(f, xs, FoldRight(f, ys, init))
   {

--- a/src/Collections/Sequences/Seq.dfy
+++ b/src/Collections/Sequences/Seq.dfy
@@ -385,7 +385,7 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* Unzips a sequence that contains pairs into two separate sequences. */
-  function {:opaque} Unzip<A,B>(xs: seq<(A, B)>): (seq<A>, seq<B>)
+  function {:opaque} Unzip<A, B>(xs: seq<(A, B)>): (seq<A>, seq<B>)
     ensures |Unzip(xs).0| == |Unzip(xs).1| == |xs|
     ensures forall i {:trigger Unzip(xs).0[i]} {:trigger Unzip(xs).1[i]}
               :: 0 <= i < |xs| ==> (Unzip(xs).0[i], Unzip(xs).1[i]) == xs[i]
@@ -397,7 +397,7 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* Zips two sequences of equal length into one sequence that consists of pairs. */
-  function {:opaque} Zip<A,B>(xs: seq<A>, ys: seq<B>): seq<(A, B)>
+  function {:opaque} Zip<A, B>(xs: seq<A>, ys: seq<B>): seq<(A, B)>
     requires |xs| == |ys|
     ensures |Zip(xs, ys)| == |xs|
     ensures forall i {:trigger Zip(xs, ys)[i]} :: 0 <= i < |Zip(xs, ys)| ==> Zip(xs, ys)[i] == (xs[i], ys[i])
@@ -409,7 +409,7 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* Unzipping and zipping a sequence results in the original sequence */
-  lemma LemmaZipOfUnzip<A,B>(xs: seq<(A,B)>)
+  lemma LemmaZipOfUnzip<A, B>(xs: seq<(A, B)>)
     ensures Zip(Unzip(xs).0, Unzip(xs).1) == xs
   {
   }
@@ -617,7 +617,7 @@ module {:options "-functionSyntax:4"} Seq {
 
   /* Returns the sequence one obtains by applying a function to every element 
      of a sequence. */
-  function {:opaque} Map<T,R>(f: (T ~> R), xs: seq<T>): (result: seq<R>)
+  function {:opaque} Map<T, R>(f: (T ~> R), xs: seq<T>): (result: seq<R>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     ensures |result| == |xs|
     ensures forall i {:trigger result[i]} :: 0 <= i < |xs| ==> result[i] == f(xs[i])
@@ -627,14 +627,14 @@ module {:options "-functionSyntax:4"} Seq {
     // more efficient when compiled, allocating the storage for |xs| elements
     // once instead of creating a chain of |xs| single element concatenations.
     seq(|xs|, i requires 0 <= i < |xs| && f.requires(xs[i])
-                reads set i,o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
+                reads set i, o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
     => f(xs[i]))
   }
 
   /* Applies a function to every element of a sequence, returning a Result value (which is a 
      failure-compatible type). Returns either a failure, or, if successful at every element, 
      the transformed sequence.  */
-  function {:opaque} MapWithResult<T, R, E>(f: (T ~> Result<R,E>), xs: seq<T>): (result: Result<seq<R>, E>)
+  function {:opaque} MapWithResult<T, R, E>(f: (T ~> Result<R, E>), xs: seq<T>): (result: Result<seq<R>, E>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     ensures result.Success? ==>
               && |result.value| == |xs|
@@ -653,7 +653,7 @@ module {:options "-functionSyntax:4"} Seq {
   /* Applying a function to a sequence  is distributive over concatenation. That is, concatenating 
      two sequences and then applying Map is the same as applying Map to each sequence separately, 
      and then concatenating the two resulting sequences. */
-  lemma {:opaque} LemmaMapDistributesOverConcat<T,R>(f: (T ~> R), xs: seq<T>, ys: seq<T>)
+  lemma {:opaque} LemmaMapDistributesOverConcat<T, R>(f: (T ~> R), xs: seq<T>, ys: seq<T>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     requires forall j :: 0 <= j < |ys| ==> f.requires(ys[j])
     ensures Map(f, xs + ys) == Map(f, xs) + Map(f, ys)
@@ -711,7 +711,7 @@ module {:options "-functionSyntax:4"} Seq {
 
   /* Folds a sequence xs from the left (the beginning), by repeatedly acting on the accumulator
      init via the function f. */
-  function {:opaque} FoldLeft<A,T>(f: (A, T) -> A, init: A, xs: seq<T>): A
+  function {:opaque} FoldLeft<A, T>(f: (A, T) -> A, init: A, xs: seq<T>): A
   {
     if |xs| == 0 then init
     else FoldLeft(f, f(init, xs[0]), xs[1..])
@@ -720,7 +720,7 @@ module {:options "-functionSyntax:4"} Seq {
   /* Folding to the left is distributive over concatenation. That is, concatenating two 
      sequences and then folding them to the left, is the same as folding to the left the 
      first sequence and using the result to fold to the left the second sequence. */
-  lemma {:opaque} LemmaFoldLeftDistributesOverConcat<A,T>(f: (A, T) -> A, init: A, xs: seq<T>, ys: seq<T>)
+  lemma {:opaque} LemmaFoldLeftDistributesOverConcat<A, T>(f: (A, T) -> A, init: A, xs: seq<T>, ys: seq<T>)
     requires 0 <= |xs + ys|
     ensures FoldLeft(f, init, xs + ys) == FoldLeft(f, FoldLeft(f, init, xs), ys)
   {
@@ -744,8 +744,8 @@ module {:options "-functionSyntax:4"} Seq {
 
   /* Is true, if inv is an invariant under stp, which is a relational 
      version of the function f passed to fold. */
-  ghost predicate InvFoldLeft<A(!new),B(!new)>(inv: (B, seq<A>) -> bool,
-                                               stp: (B, A, B) -> bool)
+  ghost predicate InvFoldLeft<A(!new), B(!new)>(inv: (B, seq<A>) -> bool,
+                                                stp: (B, A, B) -> bool)
   {
     forall x: A, xs: seq<A>, b: B, b': B ::
       inv(b, [x] + xs) && stp(b, x, b') ==> inv(b', xs)
@@ -772,7 +772,7 @@ module {:options "-functionSyntax:4"} Seq {
 
   /* Folds a sequence xs from the right (the end), by acting on the accumulator init via the 
      function f. */
-  function {:opaque} FoldRight<A,T>(f: (T, A) -> A, xs: seq<T>, init: A): A
+  function {:opaque} FoldRight<A, T>(f: (T, A) -> A, xs: seq<T>, init: A): A
   {
     if |xs| == 0 then init
     else f(xs[0], FoldRight(f, xs[1..], init))
@@ -781,7 +781,7 @@ module {:options "-functionSyntax:4"} Seq {
   /* Folding to the right is (contravariantly) distributive over concatenation. That is, concatenating
      two sequences and then folding them to the right, is the same as folding to the right 
      the second sequence and using the result to fold to the right the first sequence. */
-  lemma {:opaque} LemmaFoldRightDistributesOverConcat<A,T>(f: (T, A) -> A, init: A, xs: seq<T>, ys: seq<T>)
+  lemma {:opaque} LemmaFoldRightDistributesOverConcat<A, T>(f: (T, A) -> A, init: A, xs: seq<T>, ys: seq<T>)
     requires 0 <= |xs + ys|
     ensures FoldRight(f, xs + ys, init) == FoldRight(f, xs, FoldRight(f, ys, init))
   {
@@ -802,8 +802,8 @@ module {:options "-functionSyntax:4"} Seq {
 
   /* Is true, if inv is an invariant under stp, which is a relational version
      of the function f passed to fold. */
-  ghost predicate InvFoldRight<A(!new),B(!new)>(inv: (seq<A>, B) -> bool,
-                                                stp: (A, B, B) -> bool)
+  ghost predicate InvFoldRight<A(!new), B(!new)>(inv: (seq<A>, B) -> bool,
+                                                 stp: (A, B, B) -> bool)
   {
     forall x: A, xs: seq<A>, b: B, b': B ::
       inv(xs, b) && stp(x, b, b') ==> inv(([x] + xs), b')
@@ -828,7 +828,7 @@ module {:options "-functionSyntax:4"} Seq {
   }
 
   /* Optimized implementation of Flatten(Map(f, xs)). */
-  function FlatMap<T,R>(f: (T ~> seq<R>), xs: seq<T>): (result: seq<R>)
+  function FlatMap<T, R>(f: (T ~> seq<R>), xs: seq<T>): (result: seq<R>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     reads set i, o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
   {

--- a/src/Collections/Sets/Isets.dfy
+++ b/src/Collections/Sets/Isets.dfy
@@ -39,9 +39,9 @@ module {:options "-functionSyntax:4"} Isets {
 
   /* Construct an iset using elements of another set for which a function
   returns true. */
-    reads f.reads
   ghost function {:opaque} Filter<X(!new)>(xs: iset<X>, f: X ~> bool): (ys: iset<X>)
     requires forall x :: x in xs ==> f.requires(x)
+    reads set x, o | x in xs && o in f.reads(x) :: o
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
   {
     var ys := iset x | x in xs && f(x);

--- a/src/Collections/Sets/Isets.dfy
+++ b/src/Collections/Sets/Isets.dfy
@@ -27,9 +27,9 @@ module {:options "-functionSyntax:4"} Isets {
   }
 
   /* Map an injective function to each element of an iset. */
-  ghost function {:opaque} Map<X(!new), Y>(xs: iset<X>, f: X-->Y): (ys: iset<Y>)
     reads f.reads
     requires forall x {:trigger f.requires(x)} :: f.requires(x)
+  ghost function {:opaque} Map<X(!new), Y>(xs: iset<X>, f: X --> Y): (ys: iset<Y>)
     requires Injective(f)
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
   {
@@ -39,9 +39,9 @@ module {:options "-functionSyntax:4"} Isets {
 
   /* Construct an iset using elements of another set for which a function
   returns true. */
-  ghost function {:opaque} Filter<X(!new)>(xs: iset<X>, f: X~>bool): (ys: iset<X>)
     reads f.reads
     requires forall x {:trigger f.requires(x)} {:trigger x in xs} :: x in xs ==> f.requires(x)
+  ghost function {:opaque} Filter<X(!new)>(xs: iset<X>, f: X ~> bool): (ys: iset<X>)
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
   {
     var ys := iset x | x in xs && f(x);

--- a/src/Collections/Sets/Isets.dfy
+++ b/src/Collections/Sets/Isets.dfy
@@ -28,8 +28,8 @@ module {:options "-functionSyntax:4"} Isets {
 
   /* Map an injective function to each element of an iset. */
     reads f.reads
-    requires forall x {:trigger f.requires(x)} :: f.requires(x)
   ghost function {:opaque} Map<X(!new), Y>(xs: iset<X>, f: X --> Y): (ys: iset<Y>)
+    requires forall x :: f.requires(x)
     requires Injective(f)
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
   {
@@ -40,8 +40,8 @@ module {:options "-functionSyntax:4"} Isets {
   /* Construct an iset using elements of another set for which a function
   returns true. */
     reads f.reads
-    requires forall x {:trigger f.requires(x)} {:trigger x in xs} :: x in xs ==> f.requires(x)
   ghost function {:opaque} Filter<X(!new)>(xs: iset<X>, f: X ~> bool): (ys: iset<X>)
+    requires forall x :: x in xs ==> f.requires(x)
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
   {
     var ys := iset x | x in xs && f(x);

--- a/src/Collections/Sets/Isets.dfy
+++ b/src/Collections/Sets/Isets.dfy
@@ -27,10 +27,10 @@ module {:options "-functionSyntax:4"} Isets {
   }
 
   /* Map an injective function to each element of an iset. */
-    reads f.reads
   ghost function {:opaque} Map<X(!new), Y>(xs: iset<X>, f: X --> Y): (ys: iset<Y>)
     requires forall x :: f.requires(x)
     requires Injective(f)
+    reads f.reads
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
   {
     var ys := iset x | x in xs :: f(x);

--- a/src/Collections/Sets/Sets.dfy
+++ b/src/Collections/Sets/Sets.dfy
@@ -123,8 +123,8 @@ module {:options "-functionSyntax:4"} Sets {
 
   /* If an injective function is applied to each element of a set to construct
   another set, the two sets have the same size. */
-    requires forall x {:trigger f.requires(x)} :: f.requires(x)
   lemma LemmaMapSize<X(!new), Y>(xs: set<X>, ys: set<Y>, f: X --> Y)
+    requires forall x :: f.requires(x)
     requires Injective(f)
     requires forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     requires forall y {:trigger y in ys} :: y in ys ==> exists x :: x in xs && y == f(x)
@@ -140,8 +140,8 @@ module {:options "-functionSyntax:4"} Sets {
 
   /* Map an injective function to each element of a set. */
     reads f.reads
-    requires forall x {:trigger f.requires(x)} :: f.requires(x)
   function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X --> Y): (ys: set<Y>)
+    requires forall x :: f.requires(x)
     requires Injective(f)
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     ensures |xs| == |ys|
@@ -154,8 +154,8 @@ module {:options "-functionSyntax:4"} Sets {
   /* If a set ys is constructed using elements of another set xs for which a
   function returns true, the size of ys is less than or equal to the size of
   xs. */
-    requires forall x {:trigger f.requires(x)}{:trigger x in xs} :: x in xs ==> f.requires(x)
   lemma LemmaFilterSize<X>(xs: set<X>, ys: set<X>, f: X ~> bool)
+    requires forall x :: x in xs ==> f.requires(x)
     requires forall y {:trigger f(y)}{:trigger y in xs} :: y in ys ==> y in xs && f(y)
     ensures |ys| <= |xs|
     decreases xs, ys
@@ -171,8 +171,8 @@ module {:options "-functionSyntax:4"} Sets {
   /* Construct a set using elements of another set for which a function returns
   true. */
     reads f.reads
-    requires forall x {:trigger f.requires(x)} {:trigger x in xs} :: x in xs ==> f.requires(x)
   function {:opaque} Filter<X(!new)>(xs: set<X>, f: X ~> bool): (ys: set<X>)
+    requires forall x :: x in xs ==> f.requires(x)
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
     ensures |ys| <= |xs|
   {
@@ -206,7 +206,7 @@ module {:options "-functionSyntax:4"} Sets {
   /* Construct a set with all integers in the range [a, b). */
   function {:opaque} SetRange(a: int, b: int): (s: set<int>)
     requires a <= b
-    ensures forall i {:trigger i in s} :: a <= i < b <==> i in s
+    ensures forall i :: a <= i < b <==> i in s
     ensures |s| == b - a
     decreases b - a
   {
@@ -216,7 +216,7 @@ module {:options "-functionSyntax:4"} Sets {
   /* Construct a set with all integers in the range [0, n). */
   function {:opaque} SetRangeZeroBound(n: int): (s: set<int>)
     requires n >= 0
-    ensures forall i {:trigger i in s} :: 0 <= i < n <==> i in s
+    ensures forall i :: 0 <= i < n <==> i in s
     ensures |s| == n
   {
     SetRange(0, n)
@@ -225,7 +225,7 @@ module {:options "-functionSyntax:4"} Sets {
   /* If a set solely contains integers in the range [a, b), then its size is
   bounded by b - a. */
   lemma LemmaBoundedSetSize(x: set<int>, a: int, b: int)
-    requires forall i {:trigger i in x} :: i in x ==> a <= i < b
+    requires forall i :: i in x ==> a <= i < b
     requires a <= b
     ensures |x| <= b - a
   {

--- a/src/Collections/Sets/Sets.dfy
+++ b/src/Collections/Sets/Sets.dfy
@@ -139,10 +139,10 @@ module {:options "-functionSyntax:4"} Sets {
   }
 
   /* Map an injective function to each element of a set. */
-    reads f.reads
   function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X --> Y): (ys: set<Y>)
     requires forall x :: f.requires(x)
     requires Injective(f)
+    reads f.reads
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     ensures |xs| == |ys|
   {

--- a/src/Collections/Sets/Sets.dfy
+++ b/src/Collections/Sets/Sets.dfy
@@ -123,8 +123,8 @@ module {:options "-functionSyntax:4"} Sets {
 
   /* If an injective function is applied to each element of a set to construct
   another set, the two sets have the same size. */
-  lemma LemmaMapSize<X(!new), Y>(xs: set<X>, ys: set<Y>, f: X-->Y)
     requires forall x {:trigger f.requires(x)} :: f.requires(x)
+  lemma LemmaMapSize<X(!new), Y>(xs: set<X>, ys: set<Y>, f: X --> Y)
     requires Injective(f)
     requires forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     requires forall y {:trigger y in ys} :: y in ys ==> exists x :: x in xs && y == f(x)
@@ -139,9 +139,9 @@ module {:options "-functionSyntax:4"} Sets {
   }
 
   /* Map an injective function to each element of a set. */
-  function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X-->Y): (ys: set<Y>)
     reads f.reads
     requires forall x {:trigger f.requires(x)} :: f.requires(x)
+  function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X --> Y): (ys: set<Y>)
     requires Injective(f)
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     ensures |xs| == |ys|
@@ -154,8 +154,8 @@ module {:options "-functionSyntax:4"} Sets {
   /* If a set ys is constructed using elements of another set xs for which a
   function returns true, the size of ys is less than or equal to the size of
   xs. */
-  lemma LemmaFilterSize<X>(xs: set<X>, ys: set<X>, f: X~>bool)
     requires forall x {:trigger f.requires(x)}{:trigger x in xs} :: x in xs ==> f.requires(x)
+  lemma LemmaFilterSize<X>(xs: set<X>, ys: set<X>, f: X ~> bool)
     requires forall y {:trigger f(y)}{:trigger y in xs} :: y in ys ==> y in xs && f(y)
     ensures |ys| <= |xs|
     decreases xs, ys
@@ -170,9 +170,9 @@ module {:options "-functionSyntax:4"} Sets {
 
   /* Construct a set using elements of another set for which a function returns
   true. */
-  function {:opaque} Filter<X(!new)>(xs: set<X>, f: X~>bool): (ys: set<X>)
     reads f.reads
     requires forall x {:trigger f.requires(x)} {:trigger x in xs} :: x in xs ==> f.requires(x)
+  function {:opaque} Filter<X(!new)>(xs: set<X>, f: X ~> bool): (ys: set<X>)
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
     ensures |ys| <= |xs|
   {

--- a/src/Collections/Sets/Sets.dfy
+++ b/src/Collections/Sets/Sets.dfy
@@ -170,9 +170,9 @@ module {:options "-functionSyntax:4"} Sets {
 
   /* Construct a set using elements of another set for which a function returns
   true. */
-    reads f.reads
   function {:opaque} Filter<X(!new)>(xs: set<X>, f: X ~> bool): (ys: set<X>)
     requires forall x :: x in xs ==> f.requires(x)
+    reads set x, o | x in xs && o in f.reads(x) :: o
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
     ensures |ys| <= |xs|
   {

--- a/src/JSON/Utils/Views.Writers.dfy
+++ b/src/JSON/Utils/Views.Writers.dfy
@@ -90,9 +90,9 @@ module {:options "-functionSyntax:4"} JSON.Utils.Views.Writers {
     }
 
     function Then(fn: Writer ~> Writer) : Writer
-      reads fn.reads
       requires Valid?
       requires fn.requires(this)
+      reads fn.reads(this)
     {
       fn(this)
     }

--- a/src/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -91,7 +91,9 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -103,7 +105,9 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }
@@ -115,7 +119,9 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -127,7 +133,9 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }

--- a/src/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -91,9 +91,7 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -105,9 +103,7 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }
@@ -119,9 +115,7 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -133,9 +127,7 @@ module {:options "-functionSyntax:4"} ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }

--- a/src/Relations.dfy
+++ b/src/Relations.dfy
@@ -92,7 +92,7 @@ module {:options "-functionSyntax:4"} Relations {
     max in s && forall x | x in s && R(max, x) :: R(x, max)
   }
 
-  lemma LemmaNewFirstElementStillSortedBy<T>(x: T, s: seq<T>, lessThan: (T, T) -> bool)
+  lemma LemmaNewFirstElementStillSortedBy<T(!new)>(x: T, s: seq<T>, lessThan: (T, T) -> bool)
     requires SortedBy(s, lessThan)
     requires |s| == 0 || lessThan(x, s[0])
     requires TotalOrdering(lessThan)

--- a/src/dafny/Collections/Arrays.dfy
+++ b/src/dafny/Collections/Arrays.dfy
@@ -15,7 +15,7 @@ module Dafny.Collections.Arrays {
   import opened Relations
   import opened Seq
 
-  method BinarySearch<T>(a: array<T>, key: T, less: (T, T) -> bool) returns (r: Option<nat>)
+  method BinarySearch<T(!new)>(a: array<T>, key: T, less: (T, T) -> bool) returns (r: Option<nat>)
     requires SortedBy(a[..], (x, y) => less(x, y) || x == y)
     requires StrictTotalOrdering(less)
     ensures r.Some? ==> r.value < a.Length && a[r.value] == key

--- a/src/dafny/Collections/Isets.dfy
+++ b/src/dafny/Collections/Isets.dfy
@@ -29,7 +29,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Isets {
   /* Map an injective function to each element of an iset. */
   ghost function {:opaque} Map<X(!new), Y>(xs: iset<X>, f: X-->Y): (ys: iset<Y>)
     reads f.reads
-    requires forall x {:trigger f.requires(x)} :: f.requires(x)
+    requires forall x :: f.requires(x)
     requires Injective(f)
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
   {
@@ -41,7 +41,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Isets {
   returns true. */
   ghost function {:opaque} Filter<X(!new)>(xs: iset<X>, f: X~>bool): (ys: iset<X>)
     reads f.reads
-    requires forall x {:trigger f.requires(x)} {:trigger x in xs} :: x in xs ==> f.requires(x)
+    requires forall x :: x in xs ==> f.requires(x)
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
   {
     var ys := iset x | x in xs && f(x);

--- a/src/dafny/Collections/Isets.dfy
+++ b/src/dafny/Collections/Isets.dfy
@@ -40,8 +40,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Isets {
   /* Construct an iset using elements of another set for which a function
   returns true. */
   ghost function {:opaque} Filter<X(!new)>(xs: iset<X>, f: X~>bool): (ys: iset<X>)
-    reads f.reads
     requires forall x :: x in xs ==> f.requires(x)
+    reads set x, o | x in xs && o in f.reads(x) :: o
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
   {
     var ys := iset x | x in xs && f(x);

--- a/src/dafny/Collections/LittleEndianNat.dfy
+++ b/src/dafny/Collections/LittleEndianNat.dfy
@@ -308,8 +308,8 @@ abstract module {:options "-functionSyntax:4"} Dafny.Collections.LittleEndianNat
   /* The nat representation of a sequence and its least significant position are
   congruent. */
   lemma LemmaSeqLswModEquivalence(xs: seq<uint>)
-    requires |xs| >= 1;
-    ensures IsModEquivalent(ToNatRight(xs), First(xs), BASE());
+    requires |xs| >= 1
+    ensures IsModEquivalent(ToNatRight(xs), First(xs), BASE())
   {
     if |xs| == 1 {
       LemmaSeqLen1(xs);

--- a/src/dafny/Collections/Seqs.dfy
+++ b/src/dafny/Collections/Seqs.dfy
@@ -729,11 +729,11 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   }
 
   /* inv(b, xs) ==> inv(FoldLeft(f, b, xs), []). */
-  lemma LemmaInvFoldLeft<A,B>(inv: (B, seq<A>) -> bool,
-                              stp: (B, A, B) -> bool,
-                              f: (B, A) -> B,
-                              b: B,
-                              xs: seq<A>)
+  lemma LemmaInvFoldLeft<A(!new), B(!new)>(inv: (B, seq<A>) -> bool,
+                                           stp: (B, A, B) -> bool,
+                                           f: (B, A) -> B,
+                                           b: B,
+                                           xs: seq<A>)
     requires InvFoldLeft(inv, stp)
     requires forall b, a :: stp(b, a, f(b, a))
     requires inv(b, xs)
@@ -787,11 +787,11 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   }
 
   /* inv([], b) ==> inv(xs, FoldRight(f, xs, b)) */
-  lemma LemmaInvFoldRight<A,B>(inv: (seq<A>, B) -> bool,
-                               stp: (A, B, B) -> bool,
-                               f: (A, B) -> B,
-                               b: B,
-                               xs: seq<A>)
+  lemma LemmaInvFoldRight<A(!new), B(!new)>(inv: (seq<A>, B) -> bool,
+                                            stp: (A, B, B) -> bool,
+                                            f: (A, B) -> B,
+                                            b: B,
+                                            xs: seq<A>)
     requires InvFoldRight(inv, stp)
     requires forall a, b :: stp(a, b, f(a, b))
     requires inv([], b)
@@ -834,7 +834,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   }
 
   /* Proves that any two sequences that are sorted by a total order and that have the same elements are equal. */
-  lemma SortedUnique<T>(xs: seq<T>, ys: seq<T>, R: (T, T) -> bool)
+  lemma SortedUnique<T(!new)>(xs: seq<T>, ys: seq<T>, R: (T, T) -> bool)
     requires SortedBy(xs, R)
     requires SortedBy(ys, R)
     requires TotalOrdering(R)
@@ -854,7 +854,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   }
 
   /* Converts a set to a sequence that is ordered w.r.t. a given total order. */
-  function SetToSortedSeq<T>(s: set<T>, R: (T, T) -> bool): (xs: seq<T>)
+  function SetToSortedSeq<T(!new)>(s: set<T>, R: (T, T) -> bool): (xs: seq<T>)
     requires TotalOrdering(R)
     ensures multiset(s) == multiset(xs)
     ensures SortedBy(xs, R)
@@ -872,7 +872,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
    ***************************** */
 
   //Splits a sequence in two, sorts the two subsequences (recursively), and merges the two sorted sequences using `MergeSortedWith`
-  function MergeSortBy<T>(a: seq<T>, lessThanOrEq: (T, T) -> bool): (result :seq<T>)
+  function MergeSortBy<T(!new)>(a: seq<T>, lessThanOrEq: (T, T) -> bool): (result :seq<T>)
     requires TotalOrdering(lessThanOrEq)
     ensures multiset(a) == multiset(result)
     ensures SortedBy(result, lessThanOrEq)
@@ -916,7 +916,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
     }
   }
 
-  lemma LemmaNewFirstElementStillSortedBy<T>(x: T, s: seq<T>, lessThan: (T, T) -> bool)
+  lemma LemmaNewFirstElementStillSortedBy<T(!new)>(x: T, s: seq<T>, lessThan: (T, T) -> bool)
     requires SortedBy(s, lessThan)
     requires |s| == 0 || lessThan(x, s[0])
     requires TotalOrdering(lessThan)
@@ -925,7 +925,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
 
 
   // Helper function for MergeSortBy
-  function {:tailrecursion} MergeSortedWith<T>(left: seq<T>, right: seq<T>, lessThanOrEq: (T, T) -> bool) : (result :seq<T>)
+  function {:tailrecursion} MergeSortedWith<T(!new)>(left: seq<T>, right: seq<T>, lessThanOrEq: (T, T) -> bool): (result :seq<T>)
     requires SortedBy(left, lessThanOrEq)
     requires SortedBy(right, lessThanOrEq)
     requires TotalOrdering(lessThanOrEq)

--- a/src/dafny/Collections/Seqs.dfy
+++ b/src/dafny/Collections/Seqs.dfy
@@ -112,12 +112,12 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   }
 
   /* Any element in a slice is included in the original sequence. */
-  lemma LemmaElementFromSlice<T>(xs: seq<T>, xs':seq<T>, a: int, b: int, pos: nat)
     requires 0 <= a <= b <= |xs|;
     requires xs' == xs[a..b];
     requires a <= pos < b;
     ensures  pos - a < |xs'|;
     ensures  xs'[pos-a] == xs[pos];
+  lemma LemmaElementFromSlice<T>(xs: seq<T>, xs': seq<T>, a: int, b: int, pos: nat)
   {
   }
 
@@ -245,7 +245,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      once in its conversion to a multiset. */
   lemma LemmaMultisetHasNoDuplicates<T>(xs: seq<T>)
     requires HasNoDuplicates(xs)
-    ensures forall x {:trigger multiset(xs)[x]} | x in multiset(xs):: multiset(xs)[x] == 1
+    ensures forall x {:trigger multiset(xs)[x]} | x in multiset(xs) :: multiset(xs)[x] == 1
   {
     if |xs| == 0 {
     } else {

--- a/src/dafny/Collections/Seqs.dfy
+++ b/src/dafny/Collections/Seqs.dfy
@@ -46,7 +46,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
 
   /* Returns the last element of a non-empty sequence. */
   function Last<T>(xs: seq<T>): T
-    requires |xs| > 0;
+    requires |xs| > 0
   {
     xs[|xs|-1]
   }
@@ -54,7 +54,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Returns the subsequence of a non-empty sequence obtained by
      dropping the last element. */
   function DropLast<T>(xs: seq<T>): seq<T>
-    requires |xs| > 0;
+    requires |xs| > 0
   {
     xs[..|xs|-1]
   }
@@ -63,8 +63,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      from dropping the last element, the second consisting only of the last 
      element, is the original sequence. */
   lemma LemmaLast<T>(xs: seq<T>)
-    requires |xs| > 0;
-    ensures DropLast(xs) + [Last(xs)] == xs;
+    requires |xs| > 0
+    ensures DropLast(xs) + [Last(xs)] == xs
   {
   }
 
@@ -78,7 +78,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
 
   /* The concatenation of sequences is associative. */
   lemma LemmaConcatIsAssociative<T>(xs: seq<T>, ys: seq<T>, zs: seq<T>)
-    ensures xs + (ys + zs) == (xs + ys) + zs;
+    ensures xs + (ys + zs) == (xs + ys) + zs
   {
   }
 
@@ -106,27 +106,27 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      with that same sequence sliced from the pos-th element, is equal to the 
      original unsliced sequence. */
   lemma LemmaSplitAt<T>(xs: seq<T>, pos: nat)
-    requires pos < |xs|;
-    ensures xs[..pos] + xs[pos..] == xs;
+    requires pos < |xs|
+    ensures xs[..pos] + xs[pos..] == xs
   {
   }
 
   /* Any element in a slice is included in the original sequence. */
-    requires 0 <= a <= b <= |xs|;
-    requires xs' == xs[a..b];
-    requires a <= pos < b;
-    ensures  pos - a < |xs'|;
-    ensures  xs'[pos-a] == xs[pos];
   lemma LemmaElementFromSlice<T>(xs: seq<T>, xs': seq<T>, a: int, b: int, pos: nat)
+    requires 0 <= a <= b <= |xs|
+    requires xs' == xs[a..b]
+    requires a <= pos < b
+    ensures  pos - a < |xs'|
+    ensures  xs'[pos-a] == xs[pos]
   {
   }
 
   /* A slice (from s2..e2) of a slice (from s1..e1) of a sequence is equal to just a 
      slice (s1+s2..s1+e2) of the original sequence. */
   lemma LemmaSliceOfSlice<T>(xs: seq<T>, s1: int, e1: int, s2: int, e2: int)
-    requires 0 <= s1 <= e1 <= |xs|;
-    requires 0 <= s2 <= e2 <= e1 - s1;
-    ensures  xs[s1..e1][s2..e2] == xs[s1+s2..s1+e2];
+    requires 0 <= s1 <= e1 <= |xs|
+    requires 0 <= s2 <= e2 <= e1 - s1
+    ensures  xs[s1..e1][s2..e2] == xs[s1+s2..s1+e2]
   {
     var r1 := xs[s1..e1];
     var r2 := r1[s2..e2];
@@ -186,10 +186,10 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      elements in common between them, then the concatenated sequence xs + ys 
      will not contain duplicates either. */
   lemma {:timeLimitMultiplier 3} LemmaNoDuplicatesInConcat<T>(xs: seq<T>, ys: seq<T>)
-    requires HasNoDuplicates(xs);
-    requires HasNoDuplicates(ys);
-    requires multiset(xs) !! multiset(ys);
-    ensures HasNoDuplicates(xs+ys);
+    requires HasNoDuplicates(xs)
+    requires HasNoDuplicates(ys)
+    requires multiset(xs) !! multiset(ys)
+    ensures HasNoDuplicates(xs + ys)
   {
     reveal HasNoDuplicates();
     var zs := xs + ys;

--- a/src/dafny/Collections/Seqs.dfy
+++ b/src/dafny/Collections/Seqs.dfy
@@ -628,7 +628,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Applying a function to a sequence  is distributive over concatenation. That is, concatenating 
      two sequences and then applying Map is the same as applying Map to each sequence separately, 
      and then concatenating the two resulting sequences. */
-  lemma {:opaque} LemmaMapDistributesOverConcat<T,R>(f: (T ~> R), xs: seq<T>, ys: seq<T>)
+  lemma LemmaMapDistributesOverConcat<T,R>(f: (T ~> R), xs: seq<T>, ys: seq<T>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     requires forall j :: 0 <= j < |ys| ==> f.requires(ys[j])
     ensures Map(f, xs + ys) == Map(f, xs) + Map(f, ys)
@@ -663,7 +663,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Filtering a sequence is distributive over concatenation. That is, concatenating two sequences 
      and then using "Filter" is the same as using "Filter" on each sequence separately, and then 
      concatenating the two resulting sequences. */
-  lemma {:opaque} LemmaFilterDistributesOverConcat<T(!new)>(f: (T ~> bool), xs: seq<T>, ys: seq<T>)
+  lemma LemmaFilterDistributesOverConcat<T(!new)>(f: (T ~> bool), xs: seq<T>, ys: seq<T>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     requires forall j :: 0 <= j < |ys| ==> f.requires(ys[j])
     ensures Filter(f, xs + ys) == Filter(f, xs) + Filter(f, ys)
@@ -695,7 +695,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Folding to the left is distributive over concatenation. That is, concatenating two 
      sequences and then folding them to the left, is the same as folding to the left the 
      first sequence and using the result to fold to the left the second sequence. */
-  lemma {:opaque} LemmaFoldLeftDistributesOverConcat<A,T>(f: (A, T) -> A, init: A, xs: seq<T>, ys: seq<T>)
+  lemma LemmaFoldLeftDistributesOverConcat<A,T>(f: (A, T) -> A, init: A, xs: seq<T>, ys: seq<T>)
     requires 0 <= |xs + ys|
     ensures FoldLeft(f, init, xs + ys) == FoldLeft(f, FoldLeft(f, init, xs), ys)
   {
@@ -756,7 +756,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Folding to the right is (contravariantly) distributive over concatenation. That is, concatenating
      two sequences and then folding them to the right, is the same as folding to the right 
      the second sequence and using the result to fold to the right the first sequence. */
-  lemma {:opaque} LemmaFoldRightDistributesOverConcat<A,T>(f: (T, A) -> A, init: A, xs: seq<T>, ys: seq<T>)
+  lemma LemmaFoldRightDistributesOverConcat<A,T>(f: (T, A) -> A, init: A, xs: seq<T>, ys: seq<T>)
     requires 0 <= |xs + ys|
     ensures FoldRight(f, xs + ys, init) == FoldRight(f, xs, FoldRight(f, ys, init))
   {

--- a/src/dafny/Collections/Seqs.dfy
+++ b/src/dafny/Collections/Seqs.dfy
@@ -132,7 +132,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
     var r2 := r1[s2..e2];
     var r3 := xs[s1+s2..s1+e2];
     assert |r2| == |r3|;
-    forall i {:trigger r2[i], r3[i]}| 0 <= i < |r2| ensures r2[i] == r3[i];
+    forall i | 0 <= i < |r2|
+      ensures r2[i] == r3[i]
     {
     }
   }
@@ -179,7 +180,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Is true if there are no duplicate values in the sequence. */
   ghost predicate {:opaque} HasNoDuplicates<T>(xs: seq<T>)
   {
-    (forall i, j {:trigger xs[i], xs[j]}:: 0 <= i < |xs| && 0 <= j < |xs| && i != j ==> xs[i] != xs[j])
+    forall i, j :: 0 <= i < |xs| && 0 <= j < |xs| && i != j ==> xs[i] != xs[j]
   }
 
   /* If sequences xs and ys don't have duplicates and there are no 
@@ -194,12 +195,9 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
     reveal HasNoDuplicates();
     var zs := xs + ys;
     if |zs| > 1 {
-      assert forall i {:trigger zs[i]} :: 0 <= i < |xs| ==>
-                                            zs[i] in multiset(xs);
-      assert forall j {:trigger zs[j]} :: |xs| <= j < |zs| ==>
-                                            zs[j] in multiset(ys);
-      assert forall i, j {:trigger zs[i], zs[j]} :: i != j && 0 <= i < |xs| && |xs| <= j < |zs| ==>
-                                                      zs[i] != zs[j];
+      assert forall i :: 0 <= i < |xs| ==> zs[i] in multiset(xs);
+      assert forall j :: |xs| <= j < |zs| ==> zs[j] in multiset(ys);
+      assert forall i, j :: i != j && 0 <= i < |xs| && |xs| <= j < |zs| ==> zs[i] != zs[j];
     }
   }
 
@@ -265,7 +263,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   function {:opaque} IndexOf<T(==)>(xs: seq<T>, v: T): (i: nat)
     requires v in xs
     ensures i < |xs| && xs[i] == v
-    ensures forall j {:trigger xs[j]} :: 0 <= j < i ==> xs[j] != v
+    ensures forall j :: 0 <= j < i ==> xs[j] != v
   {
     if xs[0] == v then 0 else 1 + IndexOf(xs[1..], v)
   }
@@ -274,7 +272,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      the index of its first occurrence. Otherwise the return is None. */
   function {:opaque} IndexOfOption<T(==)>(xs: seq<T>, v: T): (o: Option<nat>)
     ensures if o.Some? then o.value < |xs| && xs[o.value] == v &&
-                            forall j {:trigger xs[j]} :: 0 <= j < o.value ==> xs[j] != v
+                            forall j :: 0 <= j < o.value ==> xs[j] != v
             else v !in xs
   {
     if |xs| == 0 then None()
@@ -290,7 +288,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   function {:opaque} LastIndexOf<T(==)>(xs: seq<T>, v: T): (i: nat)
     requires v in xs
     ensures i < |xs| && xs[i] == v
-    ensures forall j {:trigger xs[j]} :: i < j < |xs| ==> xs[j] != v
+    ensures forall j :: i < j < |xs| ==> xs[j] != v
   {
     if xs[|xs|-1] == v then |xs| - 1 else LastIndexOf(xs[..|xs|-1], v)
   }
@@ -299,7 +297,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      the index of its last occurrence. Otherwise the return is None. */
   function {:opaque} LastIndexOfOption<T(==)>(xs: seq<T>, v: T): (o: Option<nat>)
     ensures if o.Some? then o.value < |xs| && xs[o.value] == v &&
-                            forall j {:trigger xs[j]} :: o.value < j < |xs| ==> xs[j] != v
+                            forall j :: o.value < j < |xs| ==> xs[j] != v
             else v !in xs
   {
     if |xs| == 0 then None()
@@ -311,7 +309,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
     requires pos < |xs|
     ensures |ys| == |xs| - 1
     ensures forall i {:trigger ys[i], xs[i]} | 0 <= i < pos :: ys[i] == xs[i]
-    ensures forall i {:trigger ys[i]} | pos <= i < |xs| - 1 :: ys[i] == xs[i+1]
+    ensures forall i | pos <= i < |xs| - 1 :: ys[i] == xs[i+1]
   {
     xs[..pos] + xs[pos+1..]
   }
@@ -338,7 +336,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
     requires pos <= |xs|
     ensures |Insert(xs, a, pos)| == |xs| + 1
     ensures forall i {:trigger Insert(xs, a, pos)[i], xs[i]} :: 0 <= i < pos ==> Insert(xs, a, pos)[i] == xs[i]
-    ensures forall i {:trigger xs[i]} :: pos <= i < |xs| ==> Insert(xs, a, pos)[i+1] == xs[i]
+    ensures forall i :: pos <= i < |xs| ==> Insert(xs, a, pos)[i+1] == xs[i]
     ensures Insert(xs, a, pos)[pos] == a
     ensures multiset(Insert(xs, a, pos)) == multiset(xs) + multiset{a}
   {
@@ -357,7 +355,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Returns a constant sequence of a given length. */
   function {:opaque} Repeat<T>(v: T, length: nat): (xs: seq<T>)
     ensures |xs| == length
-    ensures forall i: nat {:trigger xs[i]} | i < |xs| :: xs[i] == v
+    ensures forall i: nat | i < |xs| :: xs[i] == v
   {
     if length == 0 then
       []
@@ -404,7 +402,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Returns the maximum integer value in a non-empty sequence of integers. */
   function {:opaque} Max(xs: seq<int>): int
     requires 0 < |xs|
-    ensures forall k {:trigger k in xs} :: k in xs ==> Max(xs) >= k
+    ensures forall k :: k in xs ==> Max(xs) >= k
     ensures Max(xs) in xs
   {
     assert xs == [xs[0]] + xs[1..];
@@ -430,7 +428,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Returns the minimum integer value in a non-empty sequence of integers. */
   function {:opaque} Min(xs: seq<int>): int
     requires 0 < |xs|
-    ensures forall k {:trigger k in xs} :: k in xs ==> Min(xs) <= k
+    ensures forall k :: k in xs ==> Min(xs) <= k
     ensures Min(xs) in xs
   {
     assert xs == [xs[0]] + xs[1..];
@@ -579,7 +577,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      to the length of xs multiplied by a number not smaller than the length of the 
      longest sequence in xs. */
   lemma LemmaFlattenLengthLeMul<T>(xs: seq<seq<T>>, j: int)
-    requires forall i {:trigger xs[i]} | 0 <= i < |xs| :: |xs[i]| <= j
+    requires forall i | 0 <= i < |xs| :: |xs[i]| <= j
     ensures |FlattenReverse(xs)| <= |xs| * j
   {
     if |xs| == 0 {
@@ -599,10 +597,10 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   /* Returns the sequence one obtains by applying a function to every element 
      of a sequence. */
   function {:opaque} Map<T,R>(f: (T ~> R), xs: seq<T>): (result: seq<R>)
-    requires forall i {:trigger xs[i]} :: 0 <= i < |xs| ==> f.requires(xs[i])
+    requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
+    reads set i, o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
     ensures |result| == |xs|
-    ensures forall i {:trigger result[i]}:: 0 <= i < |xs| ==> result[i] == f(xs[i]);
-    reads set i, o {:trigger o in f.reads(xs[i])} | 0 <= i < |xs| && o in f.reads(xs[i]):: o
+    ensures forall i {:trigger result[i]} :: 0 <= i < |xs| ==> result[i] == f(xs[i])
   {
     if |xs| == 0 then []
     else [f(xs[0])] + Map(f, xs[1..])
@@ -631,8 +629,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      two sequences and then applying Map is the same as applying Map to each sequence separately, 
      and then concatenating the two resulting sequences. */
   lemma {:opaque} LemmaMapDistributesOverConcat<T,R>(f: (T ~> R), xs: seq<T>, ys: seq<T>)
-    requires forall i {:trigger xs[i]}:: 0 <= i < |xs| ==> f.requires(xs[i])
-    requires forall j {:trigger ys[j]}:: 0 <= j < |ys| ==> f.requires(ys[j])
+    requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
+    requires forall j :: 0 <= j < |ys| ==> f.requires(ys[j])
     ensures Map(f, xs + ys) == Map(f, xs) + Map(f, ys)
   {
     reveal Map();
@@ -655,8 +653,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
   function {:opaque} Filter<T>(f: (T ~> bool), xs: seq<T>): (result: seq<T>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
     ensures |result| <= |xs|
-    ensures forall i: nat {:trigger result[i]} :: i < |result| && f.requires(result[i]) ==> f(result[i])
     reads set i, o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
+    ensures forall i: nat :: i < |result| && f.requires(result[i]) ==> f(result[i])
   {
     if |xs| == 0 then []
     else (if f(xs[0]) then [xs[0]] else []) + Filter(f, xs[1..])
@@ -666,8 +664,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      and then using "Filter" is the same as using "Filter" on each sequence separately, and then 
      concatenating the two resulting sequences. */
   lemma {:opaque} LemmaFilterDistributesOverConcat<T(!new)>(f: (T ~> bool), xs: seq<T>, ys: seq<T>)
-    requires forall i {:trigger xs[i]}:: 0 <= i < |xs| ==> f.requires(xs[i])
-    requires forall j {:trigger ys[j]}:: 0 <= j < |ys| ==> f.requires(ys[j])
+    requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
+    requires forall j :: 0 <= j < |ys| ==> f.requires(ys[j])
     ensures Filter(f, xs + ys) == Filter(f, xs) + Filter(f, ys)
   {
     reveal Filter();

--- a/src/dafny/Collections/Seqs.dfy
+++ b/src/dafny/Collections/Seqs.dfy
@@ -611,12 +611,12 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      the transformed sequence.  */
   function {:opaque} MapWithResult<T, R, E>(f: (T ~> Result<R,E>), xs: seq<T>): (result: Result<seq<R>, E>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
+    reads set i, o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
     ensures result.Success? ==>
               && |result.value| == |xs|
               && (forall i :: 0 <= i < |xs| ==>
                                 && f(xs[i]).Success?
                                 && result.value[i] == f(xs[i]).value)
-    reads set i, o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
   {
     if |xs| == 0 then Success([])
     else
@@ -652,8 +652,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Seq {
      predicate. */
   function {:opaque} Filter<T>(f: (T ~> bool), xs: seq<T>): (result: seq<T>)
     requires forall i :: 0 <= i < |xs| ==> f.requires(xs[i])
-    ensures |result| <= |xs|
     reads set i, o | 0 <= i < |xs| && o in f.reads(xs[i]) :: o
+    ensures |result| <= |xs|
     ensures forall i: nat :: i < |result| && f.requires(result[i]) ==> f(result[i])
   {
     if |xs| == 0 then []

--- a/src/dafny/Collections/Sets.dfy
+++ b/src/dafny/Collections/Sets.dfy
@@ -121,8 +121,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
 
   /* If an injective function is applied to each element of a set to construct
   another set, the two sets have the same size.  */
-  lemma LemmaMapSize<X(!new), Y>(xs: set<X>, ys: set<Y>, f: X-->Y)
     requires forall x {:trigger f.requires(x)} :: f.requires(x)
+  lemma LemmaMapSize<X(!new), Y>(xs: set<X>, ys: set<Y>, f: X --> Y)
     requires Injective(f)
     requires forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     requires forall y {:trigger y in ys} :: y in ys ==> exists x :: x in xs && y == f(x)
@@ -137,9 +137,9 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   }
 
   /* Map an injective function to each element of a set. */
-  function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X-->Y): (ys: set<Y>)
     reads f.reads
     requires forall x {:trigger f.requires(x)} :: f.requires(x)
+  function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X --> Y): (ys: set<Y>)
     requires Injective(f)
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     ensures |xs| == |ys|
@@ -152,8 +152,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   /* If a set ys is constructed using elements of another set xs for which a
   function returns true, the size of ys is less than or equal to the size of
   xs. */
-  lemma LemmaFilterSize<X>(xs: set<X>, ys: set<X>, f: X~>bool)
     requires forall x {:trigger f.requires(x)}{:trigger x in xs} :: x in xs ==> f.requires(x)
+  lemma LemmaFilterSize<X>(xs: set<X>, ys: set<X>, f: X ~> bool)
     requires forall y {:trigger f(y)}{:trigger y in xs} :: y in ys ==> y in xs && f(y)
     ensures |ys| <= |xs|
     decreases xs, ys
@@ -168,9 +168,9 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
 
   /* Construct a set using elements of another set for which a function returns
   true. */
-  function {:opaque} Filter<X(!new)>(xs: set<X>, f: X~>bool): (ys: set<X>)
     reads f.reads
     requires forall x {:trigger f.requires(x)} {:trigger x in xs} :: x in xs ==> f.requires(x)
+  function {:opaque} Filter<X(!new)>(xs: set<X>, f: X ~> bool): (ys: set<X>)
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
     ensures |ys| <= |xs|
   {

--- a/src/dafny/Collections/Sets.dfy
+++ b/src/dafny/Collections/Sets.dfy
@@ -168,9 +168,9 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
 
   /* Construct a set using elements of another set for which a function returns
   true. */
-    reads f.reads
   function {:opaque} Filter<X(!new)>(xs: set<X>, f: X ~> bool): (ys: set<X>)
     requires forall x :: x in xs ==> f.requires(x)
+    reads set x, o | x in xs && o in f.reads(x) :: o
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
     ensures |ys| <= |xs|
   {

--- a/src/dafny/Collections/Sets.dfy
+++ b/src/dafny/Collections/Sets.dfy
@@ -121,11 +121,11 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
 
   /* If an injective function is applied to each element of a set to construct
   another set, the two sets have the same size.  */
-    requires forall x {:trigger f.requires(x)} :: f.requires(x)
   lemma LemmaMapSize<X(!new), Y>(xs: set<X>, ys: set<Y>, f: X --> Y)
+    requires forall x :: f.requires(x)
     requires Injective(f)
     requires forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
-    requires forall y {:trigger y in ys} :: y in ys ==> exists x :: x in xs && y == f(x)
+    requires forall y :: y in ys ==> exists x :: x in xs && y == f(x)
     ensures |xs| == |ys|
   {
     if xs != {} {
@@ -138,8 +138,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
 
   /* Map an injective function to each element of a set. */
     reads f.reads
-    requires forall x {:trigger f.requires(x)} :: f.requires(x)
   function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X --> Y): (ys: set<Y>)
+    requires forall x :: f.requires(x)
     requires Injective(f)
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     ensures |xs| == |ys|
@@ -152,8 +152,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   /* If a set ys is constructed using elements of another set xs for which a
   function returns true, the size of ys is less than or equal to the size of
   xs. */
-    requires forall x {:trigger f.requires(x)}{:trigger x in xs} :: x in xs ==> f.requires(x)
   lemma LemmaFilterSize<X>(xs: set<X>, ys: set<X>, f: X ~> bool)
+    requires forall x :: x in xs ==> f.requires(x)
     requires forall y {:trigger f(y)}{:trigger y in xs} :: y in ys ==> y in xs && f(y)
     ensures |ys| <= |xs|
     decreases xs, ys
@@ -169,8 +169,8 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   /* Construct a set using elements of another set for which a function returns
   true. */
     reads f.reads
-    requires forall x {:trigger f.requires(x)} {:trigger x in xs} :: x in xs ==> f.requires(x)
   function {:opaque} Filter<X(!new)>(xs: set<X>, f: X ~> bool): (ys: set<X>)
+    requires forall x :: x in xs ==> f.requires(x)
     ensures forall y {:trigger f(y)}{:trigger y in xs} :: y in ys <==> y in xs && f(y)
     ensures |ys| <= |xs|
   {
@@ -204,7 +204,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   /* Construct a set with all integers in the range [a, b). */
   function {:opaque} SetRange(a: int, b: int): (s: set<int>)
     requires a <= b
-    ensures forall i {:trigger i in s} :: a <= i < b <==> i in s
+    ensures forall i :: a <= i < b <==> i in s
     ensures |s| == b - a
     decreases b - a
   {
@@ -214,7 +214,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   /* Construct a set with all integers in the range [0, n). */
   function {:opaque} SetRangeZeroBound(n: int): (s: set<int>)
     requires n >= 0
-    ensures forall i {:trigger i in s} :: 0 <= i < n <==> i in s
+    ensures forall i :: 0 <= i < n <==> i in s
     ensures |s| == n
   {
     SetRange(0, n)
@@ -223,7 +223,7 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   /* If a set solely contains integers in the range [a, b), then its size is
   bounded by b - a. */
   lemma LemmaBoundedSetSize(x: set<int>, a: int, b: int)
-    requires forall i {:trigger i in x} :: i in x ==> a <= i < b
+    requires forall i :: i in x ==> a <= i < b
     requires a <= b
     ensures |x| <= b - a
   {

--- a/src/dafny/Collections/Sets.dfy
+++ b/src/dafny/Collections/Sets.dfy
@@ -137,10 +137,10 @@ module {:options "-functionSyntax:4"} Dafny.Collections.Sets {
   }
 
   /* Map an injective function to each element of a set. */
-    reads f.reads
   function {:opaque} Map<X(!new), Y>(xs: set<X>, f: X --> Y): (ys: set<Y>)
     requires forall x :: f.requires(x)
     requires Injective(f)
+    reads f.reads
     ensures forall x {:trigger f(x)} :: x in xs <==> f(x) in ys
     ensures |xs| == |ys|
   {

--- a/src/dafny/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/dafny/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -91,7 +91,9 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -103,7 +105,9 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }
@@ -115,7 +119,9 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -127,7 +133,9 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
+    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
+      LemmaMulAuto();
+    }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }

--- a/src/dafny/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/dafny/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -91,9 +91,7 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -105,9 +103,7 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }
@@ -119,9 +115,7 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x + n, n);
     var zp := (x + n) / n - x / n - 1;
-    assert 0 == n * zp + ((x + n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zp + ((x + n) % n) - (x % n) { LemmaMulAuto(); }
     if (zp > 0) { LemmaMulInequality(1, zp, n); }
     if (zp < 0) { LemmaMulInequality(zp, -1, n); }
   }
@@ -133,9 +127,7 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
     LemmaFundamentalDivMod(x, n);
     LemmaFundamentalDivMod(x - n, n);
     var zm := (x - n) / n - x / n + 1;
-    assert 0 == n * zm + ((x - n) % n) - (x % n) by {
-      LemmaMulAuto();
-    }
+    forall ensures 0 == n * zm + ((x - n) % n) - (x % n) { LemmaMulAuto(); }
     if (zm > 0) { LemmaMulInequality(1, zm, n); }
     if (zm < 0) { LemmaMulInequality(zm, -1, n); }
   }

--- a/src/dafny/NonlinearArithmetic/Internals/ModInternals.dfy
+++ b/src/dafny/NonlinearArithmetic/Internals/ModInternals.dfy
@@ -199,7 +199,7 @@ module {:options "-functionSyntax:4"} Dafny.ModInternals {
 
   /* automates the modulus operator process */
   ghost predicate ModAuto(n: int)
-    requires n > 0;
+    requires n > 0
   {
     && (n % n == (-n) % n == 0)
     && (forall x: int {:trigger (x % n) % n} :: (x % n) % n == x % n)

--- a/src/dafny/NonlinearArithmetic/Multiply.dfy
+++ b/src/dafny/NonlinearArithmetic/Multiply.dfy
@@ -79,7 +79,7 @@ module {:options "-functionSyntax:4"} Dafny.Multiply {
     ensures forall x: int, y: int {:trigger x * y} :: x * y != 0 <==> x != 0 && y != 0
   {
     forall (x: int, y: int)
-      ensures x * y != 0 <==> x != 0 && y != 0;
+      ensures x * y != 0 <==> x != 0 && y != 0
     {
       LemmaMulNonzero(x, y);
     }
@@ -332,7 +332,7 @@ module {:options "-functionSyntax:4"} Dafny.Multiply {
     ensures  forall x: int, y: int, z: int {:trigger x * z, y * z} :: x * z < y * z && z >= 0 ==> x < y
   {
     forall (x: int, y: int, z: int | x * z < y * z && z >= 0)
-      ensures x < y;
+      ensures x < y
     {
       LemmaMulStrictInequalityConverse(x, y, z);
     }
@@ -385,7 +385,7 @@ module {:options "-functionSyntax:4"} Dafny.Multiply {
     ensures forall x: int, y: int, z: int {:trigger x * (y - z)} :: x * (y - z) == x * y - x * z
   {
     forall (x: int, y: int, z: int)
-      ensures x * (y - z) == x * y - x * z;
+      ensures x * (y - z) == x * y - x * z
     {
       LemmaMulIsDistributiveSub(x, y, z);
     }

--- a/src/dafny/NonlinearArithmetic/Power.dfy
+++ b/src/dafny/NonlinearArithmetic/Power.dfy
@@ -590,7 +590,7 @@ module {:options "-functionSyntax:4"} Dafny.Power {
   /* b^e % b = 0 */
   lemma LemmaPowMod(b: nat, e: nat)
     requires b > 0 && e > 0
-    ensures Pow(b, e) % b == 0;
+    ensures Pow(b, e) % b == 0
   {
     reveal Pow();
     calc {


### PR DESCRIPTION
This PR primarily adds missing `(!new)` type characteristics in function declarations. These had gone undetected, because of a latent [bug](https://github.com/dafny-lang/dafny/issues/4926) that has now been [fixed](https://github.com/dafny-lang/dafny/pull/4928). The bug fix requires these fixes in the libraries.

This PR also cleans up some library files: removing deprecated semi-colons, removing unnecessary parentheses, stylizing order of specification clauses, and removing explicit triggers that are saying the same thing as those triggers that are automatically inferred.

~~The PR also changes `forall ensures ...` statements with no bound variables into `assert ... by` statements. (I think we attempted this change once before, only to find that the change tickled some brittleness issue. Let's see if they verify this time.)~~

Finally, the PR improves some `reads fn` clauses, where `fn` is some function. In one case, such a `reads` clause was probably accidentally (and I changed it to the more specific `reads fn(this)`). In the other cases, the `reads fn` clause had ended up reading more than the enclosing function's precondition could support. The new `reads` clauses are more specific than the previous, so, semantically, they should not affect callers. I'm surprised how these were not detected before (am I perhaps running the wrong version of Dafny when running the `libraries` test suite?). In fact, I also received an error, which I _think_ is due to that a previous version of Dafny didn't assume `requires` clauses when checking `reads` clauses in lambda expressions (or was it perhaps the other way around?). If there's still a problem with my modifications, I hope CI will discover them.

Hint to reviewers: If you want to see each of the simple modifications, I suggest looking at each commit individually.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
