### PR TITLE
fix: correct Unicode handling in JSON  

### DIFF
--- a/src/JSON/Deserializer.dfy
+++ b/src/JSON/Deserializer.dfy
@@ -77,7 +77,7 @@ module {:options "-functionSyntax:4"} JSON.Deserializer {
       else
         var c := str[start + 1];
         if c == 'u' as uint16 then
-          if |str| <= start + 6 then
+          if |str| < start + 6 then
             Failure(EscapeAtEOS)
           else
             var code := str[start + 2..start + 6];

--- a/src/JSON/Spec.dfy
+++ b/src/JSON/Spec.dfy
@@ -45,7 +45,7 @@ module {:options "-functionSyntax:4"} JSON.Spec {
       }
       assert Log(16, 0xFFFF) == 3 by { reveal Log(); }
     }
-    s + seq(4 - |s|, _ => ' ' as uint16)
+    seq(4 - |s|, _ => '0' as uint16) + s
   }
 
   function Escape(str: seq<uint16>, start: nat := 0): seq<uint16>


### PR DESCRIPTION
fixes 
- Unicode escape sequence padding with leading zeros instead of trailing spaces
- Error condition to be only when str legnth is < 6 but not <= 6

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
